### PR TITLE
Added topic cache json to datacommons-mcp package, updated readme, consolidated version definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,61 +11,54 @@ This is an experimental MCP server for fetching public information from [Data Co
 
 ## Getting Started
 
-1.  Clone the repository.
-2.  Run the server.
+Run the server with `uvx`:
 
-    You can run the server in a few different ways:
+**stdio**
 
-    **stdio**
+```bash
+DC_API_KEY=<your-key> uvx datacommons-mcp serve stdio
+```
 
-    ```bash
-    DC_API_KEY=<your-key> uv run datacommons-mcp serve stdio
-    ```
+**http**
 
-    **http**
+This will run the server with SSE on port 8080. You can access it at `http://localhost:8080/sse`.
 
-    This will run the server with SSE on port 8080. You can access it at `http://localhost:8080/sse`.
+```bash
+DC_API_KEY=<your-key> uvx datacommons-mcp serve http
+```
 
-    ```bash
-    DC_API_KEY=<your-key> uv run datacommons-mcp serve http
-    ```
+**Debugging**
 
-    **Debugging**
+You can start the MCP inspector on port 6277. Look at the output for the pre-filled proxy auth token URL.
 
-    You can start the MCP inspector on port 6277. Look at the output for the pre-filled proxy auth token URL.
+```bash
+DC_API_KEY=<your-key> npx @modelcontextprotocol/inspector uvx datacommons-mcp serve stdio
+```
 
-    ```bash
-    DC_API_KEY=<your-key> npx @modelcontextprotocol/inspector uv run datacommons-mcp serve stdio
-    ```
+> IMPORTANT: Open the inspector via the **pre-filled session token url** which is printed to terminal on server startup.
+> * It should look like `http://localhost:6274/?MCP_PROXY_AUTH_TOKEN={session_token}`
 
+Then to connect to this MCP server, enter the following values in the inspector UI:
 
-    > IMPORTANT: Open the inspector via the **pre-filled session token url** which is printed to terminal on server startup.
-    * It should look like `http://localhost:6274/?MCP_PROXY_AUTH_TOKEN={session_token}`
+- Transport Type: `STDIO`
+- Command: `uvx`
+- Arguments: `datacommons-mcp serve stdio`
 
-    Then to connect to this MCP server, enter the following values in the inspector UI:
-
-    - Transport Type: `STDIO`
-    - Command: `uv`
-    - Arguments: `run datacommons-mcp serve stdio`
-
-    Click `Connect`
+Click `Connect`
 
 ## Testing with Gemini CLI
 
 You can use this MCP server with the [Gemini CLI](https://github.com/google-gemini/gemini-cli).
 
-Edit your `~/.gemini/settings.json` file and add the following, replacing `/path/to/your/agent-toolkit` with the local checkout directory and `<your api key>` with your actual API key:
+Edit your `~/.gemini/settings.json` file and add the following, replacing `<your api key>` with your actual API key:
 
 ```json
 {
   ...
   "mcpServers": {
     "datacommons-mcp": {
-      "command": "uv",
+      "command": "uvx",
       "args": [
-        "--directory",
-        "/path/to/your/agent-toolkit/",
-        "run",
         "datacommons-mcp",
         "serve",
         "stdio"

--- a/packages/datacommons-mcp/datacommons_mcp/__init__.py
+++ b/packages/datacommons-mcp/datacommons_mcp/__init__.py
@@ -2,4 +2,4 @@
 DataCommons MCP Server Package
 """
 
-__version__ = "0.1.0"
+from .version import __version__

--- a/packages/datacommons-mcp/datacommons_mcp/version.py
+++ b/packages/datacommons-mcp/datacommons_mcp/version.py
@@ -1,0 +1,5 @@
+"""
+Version information for datacommons-mcp package.
+"""
+
+__version__ = "0.1.1"

--- a/packages/datacommons-mcp/pyproject.toml
+++ b/packages/datacommons-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datacommons-mcp"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Data Commons MCP server."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -11,6 +11,7 @@ dependencies = [
     "requests",
     "datacommons-client",
 ]
+urls = {Homepage = "https://github.com/datacommonsorg/agent-toolkit"}
 
 [project.scripts]
 datacommons-mcp = "datacommons_mcp.cli:cli"
@@ -18,3 +19,12 @@ datacommons-mcp = "datacommons_mcp.cli:cli"
 [build-system]
 requires = ["uv", "setuptools"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.package-data]
+datacommons_mcp = ["*.json"]
+
+[tool.setuptools.dynamic]
+version = {attr = "datacommons_mcp.version.__version__"}


### PR DESCRIPTION
* Added topic_cache.json to the datacommons-mcp pypi package, which fixes a bug where running

```
DC_API_KEY=<your_key> uvx datacommons-mcp serve http
```

gave the error: 

```
FileNotFoundError: [Errno 2] No such file or directory: '.../python3.13/site-packages/datacommons_mcp/topic_cache.json'
```

* Updated readme to use uvx commands
* Bumped version to 0.1.1
* Consolidated version definition to be in only one place (version.py)