### PR TITLE
Remove legacy prototype files.

### DIFF
--- a/packages/datacommons-mcp/datacommons_mcp/Procfile
+++ b/packages/datacommons-mcp/datacommons_mcp/Procfile
@@ -1,1 +1,0 @@
-web: python server.py

--- a/packages/datacommons-mcp/datacommons_mcp/requirements.txt
+++ b/packages/datacommons-mcp/datacommons_mcp/requirements.txt
@@ -1,9 +1,0 @@
-fastmcp
-asyncio
-datacommons-client
-requests
-python-dotenv>=1.0.0
-pydantic
-fastapi
-uvicorn
-uv


### PR DESCRIPTION
Since we are using uv and deploying to pypi, we don't need a separate requirements.txt nor the Procfile.