### PR TITLE
Disable pypi publish GitHub Action for forks

### DIFF
--- a/.github/workflows/build-and-publish-datacommons-mcp.yaml
+++ b/.github/workflows/build-and-publish-datacommons-mcp.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   # JOB 1: Detects if the version was bumped
   check_version:
+    if: github.repository == 'datacommonsorg/agent-tool-kit'
     runs-on: ubuntu-latest
     # This job produces outputs that the next job will use
     outputs:

--- a/.github/workflows/build-and-publish-datacommons-mcp.yaml
+++ b/.github/workflows/build-and-publish-datacommons-mcp.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   # JOB 1: Detects if the version was bumped
   check_version:
-    if: github.repository == 'datacommonsorg/agent-tool-kit'
+    if: github.repository == 'datacommonsorg/agent-toolkit'
     runs-on: ubuntu-latest
     # This job produces outputs that the next job will use
     outputs:


### PR DESCRIPTION
I noticed that the publish action was executed on my fork: https://github.com/clincoln8/dc-agent-toolkit/actions
- although it's not harmful since the credentials are required, it seems better to not have this run at all for forks

Following similar logic to some of the website repo GH actions: [example](https://github.com/clincoln8/datcom-website/blob/master/.github/workflows/submodule-update.yml#L12C5-L12C29)

Tested on my fork: 
<img width="3024" height="1646" alt="image" src="https://github.com/user-attachments/assets/c021a244-f466-420e-8c06-ceda69356836" />
