### PR TITLE
Add support for fetching topics and variables in dc client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,5 @@ Thumbs.db
 # VSCode
 .vscode
 
+# Gemini
+gemini.md

--- a/packages/datacommons-mcp/datacommons_mcp/cache.py
+++ b/packages/datacommons-mcp/datacommons_mcp/cache.py
@@ -24,7 +24,7 @@ class LruCache:
         self.cache = collections.OrderedDict()
         self.capacity = capacity
 
-    def get(self, key: str) -> list[str]:
+    def get(self, key: str) -> set[str]:
         """
         Retrieves an item from the cache and marks it as recently used.
         Returns None if the key is not found.
@@ -34,7 +34,7 @@ class LruCache:
         self.cache.move_to_end(key)
         return self.cache[key]
 
-    def put(self, key: str, value: list[str]) -> None:
+    def put(self, key: str, value: set[str]) -> None:
         """
         Adds an item to the cache. If the cache is full, the least
         recently used item is removed.


### PR DESCRIPTION
* This function will be used by the mcp tool for searching topics and variables.
* Performs existence checks on both topics and variables if place is specified.
* Updated topic store to only store direct member variables since were recursively do topic existence checks and storing all descendant variables is not required.
* Updated variable cache to store set instead of list to improve lookup performance.
* Tested with local test functions for now. Will add unit tests and typed classes in follow-on PRs.