### PR TITLE
Add support for Streamable HTTP 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,4 @@ Thumbs.db
 
 # Gemini
 gemini.md
+/.idea

--- a/packages/datacommons-mcp/README.md
+++ b/packages/datacommons-mcp/README.md
@@ -26,6 +26,14 @@ This will run the server with SSE on port 8080. You can access it at `http://loc
 ```bash
 DC_API_KEY=<your-key> uvx datacommons-mcp serve http
 ```
+**Streamable http**
+
+This will run the server with Streamable HTTP on port 8080. You can access it at `http://localhost:8080/mcp`.
+Since SSE is deprecated by the MCP standard, this option is now recommended.
+
+```bash
+DC_API_KEY=<your-key> uvx datacommons-mcp serve streamable_http
+```
 
 **Debugging**
 

--- a/packages/datacommons-mcp/datacommons_mcp/cli.py
+++ b/packages/datacommons-mcp/datacommons_mcp/cli.py
@@ -39,6 +39,27 @@ def http(host: str, port: int, reload: bool) -> None:
         click.echo(f"Error importing server: {e}", err=True)
         sys.exit(1)
 
+@serve.command()
+@click.option("--host", default="localhost", help="Host to bind.")
+@click.option("--port", default=8080, help="Port to bind.", type=int)
+@click.option("--reload", is_flag=True, help="Enable auto-reload on code changes.")
+def streamable_http(host: str, port: int, reload: bool) -> None:
+    """Start the MCP server in Streamable HTTP mode."""
+    try:
+        from datacommons_mcp.server import mcp
+
+        click.echo("Starting DataCommons MCP server in Streamable HTTP mode")
+        click.echo(f"Server URL: http://{host}:{port}")
+        click.echo(f"SSE endpoint: http://{host}:{port}/mcp")
+        click.echo("Press CTRL+C to stop")
+
+        mcp.run(host=host, port=port, transport="streamable-http")
+
+    except ImportError as e:
+        click.echo(f"Error importing server: {e}", err=True)
+        sys.exit(1)
+
+
 
 @serve.command()
 def stdio() -> None:


### PR DESCRIPTION
This pull request adds support for running the MCP server using Streamable HTTP, which is now recommended over SSE due to deprecation. The changes include a new CLI command and updated instructions in the README.

* Added a new `streamable_http` command to `packages/datacommons-mcp/datacommons_mcp/cli.py`, allowing users to start the server in Streamable HTTP mode with configurable host, port, and reload options.
* Updated `packages/datacommons-mcp/README.md` to recommend Streamable HTTP for running the server, with new instructions and a note about SSE deprecation.
