### PR TITLE
[cleanup] Automate ruff formatting, fix ruff checks, isolate test_settings from local .env

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,10 @@ jobs:
       - name: Install uv
         run: pip install uv
 
+      - name: Install dependencies
+        # This will install all dependencies from the workspace pyproject.toml
+        run: uv sync
+
       - name: Check formatting with Ruff
         # Run from the package directory
         working-directory: packages/datacommons-mcp

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,13 +23,13 @@ jobs:
       - name: Install uv
         run: pip install uv
 
-      #   TODO(clincoln8): Uncomment when pre-commit hooks are ready and repo is in healthy state.
-      #   - name: Check formatting with Ruff
-      #     # Run from the package directory
-      #     working-directory: packages/datacommons-mcp
-      #     # The --check flag will fail if the code is not formatted correctly
-      #     run: uv run ruff format --check
+      - name: Check formatting with Ruff
+        # Run from the package directory
+        working-directory: packages/datacommons-mcp
+        # The --check flag will fail if the code is not formatted correctly
+        run: uv run ruff format --check
 
+      #   TODO(clincoln8): Uncomment when pre-commit hooks are ready and repo is in healthy state.
       #   - name: Lint with Ruff
       #     working-directory: packages/datacommons-mcp
       #     run: uv run ruff check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
         name: pytest
         entry: uv run pytest packages/datacommons-mcp/tests
         pass_filenames: False
+        files: ^packages/datacommons-mcp/
         language: system
         stages: [pre-push]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: pytest
         name: pytest
         env: {DC_API_KEY: "test"}
-        entry: uv run pytest packages/datacommons-mcp/
+        entry: uv run pytest packages/datacommons-mcp/tests
         files: ^packages/datacommons-mcp/
         language: system
         types: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: pytest
         name: pytest
         entry: uv run pytest packages/datacommons-mcp/tests
-        files: ^packages/datacommons-mcp/
+        pass_filenames: False
         language: system
         stages: [pre-push]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,8 @@ repos:
       #   stages: [pre-push]
       - id: pytest
         name: pytest
-        entry: uv run pytest
+        entry: uv run pytest packages/datacommons-mcp/
+        files: ^packages/datacommons-mcp/
         language: system
         types: [python]
         stages: [pre-push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+  - repo: local
+    hooks:
+      - id: ruff-format
+        name: ruff-format
+        entry: uv run ruff format
+        language: system
+        types: [python]
+        args: []
+        stages: [pre-push]
+      # TODO(clincoln8): Uncomment when repo is in healthy state.
+      # - id: ruff-check
+      #   name: ruff-check
+      #   entry: uv run ruff check
+      #   language: system
+      #   types: [python]
+      #   args: [--fix]
+      #   stages: [pre-push]
+      - id: pytest
+        name: pytest
+        entry: uv run pytest
+        language: system
+        types: [python]
+        stages: [pre-push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,9 +18,8 @@ repos:
       #   stages: [pre-push]
       - id: pytest
         name: pytest
-        # env: {DC_API_KEY: "test"}
         entry: uv run pytest packages/datacommons-mcp/tests
-        # files: ^packages/datacommons-mcp/
+        files: ^packages/datacommons-mcp/
         language: system
-        types: [python]
         stages: [pre-push]
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,7 @@ repos:
       #   stages: [pre-push]
       - id: pytest
         name: pytest
+        env: {DC_API_KEY: "test"}
         entry: uv run pytest packages/datacommons-mcp/
         files: ^packages/datacommons-mcp/
         language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       #   stages: [pre-push]
       - id: pytest
         name: pytest
-        env: {DC_API_KEY: "test"}
+        # env: {DC_API_KEY: "test"}
         entry: uv run pytest packages/datacommons-mcp/tests
         files: ^packages/datacommons-mcp/
         language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         name: pytest
         # env: {DC_API_KEY: "test"}
         entry: uv run pytest packages/datacommons-mcp/tests
-        files: ^packages/datacommons-mcp/
+        # files: ^packages/datacommons-mcp/
         language: system
         types: [python]
         stages: [pre-push]

--- a/packages/datacommons-mcp/datacommons_mcp/cli.py
+++ b/packages/datacommons-mcp/datacommons_mcp/cli.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 
 import click
@@ -6,6 +7,7 @@ import click
 @click.group()
 def cli() -> None:
     """DataCommons MCP CLI - Model Context Protocol server for Data Commons."""
+    logging.basicConfig(level=logging.INFO)
 
 
 @cli.command()

--- a/packages/datacommons-mcp/datacommons_mcp/cli.py
+++ b/packages/datacommons-mcp/datacommons_mcp/cli.py
@@ -24,8 +24,7 @@ def serve() -> None:
 @serve.command()
 @click.option("--host", default="localhost", help="Host to bind.")
 @click.option("--port", default=8080, help="Port to bind.", type=int)
-@click.option("--reload", is_flag=True, help="Enable auto-reload on code changes.")
-def http(host: str, port: int, reload: bool) -> None:
+def http(host: str, port: int) -> None:
     """Start the MCP server in Streamable HTTP mode."""
     try:
         from datacommons_mcp.server import mcp

--- a/packages/datacommons-mcp/datacommons_mcp/data_models/enums.py
+++ b/packages/datacommons-mcp/datacommons_mcp/data_models/enums.py
@@ -21,6 +21,7 @@ from enum import Enum
 
 class SearchScope(Enum):
     """Enum for controlling search scope in Data Commons queries."""
+
     CUSTOM_ONLY = "custom_only"
     BASE_ONLY = "base_only"
     BASE_AND_CUSTOM = "base_and_custom"

--- a/packages/datacommons-mcp/datacommons_mcp/data_models/observations.py
+++ b/packages/datacommons-mcp/datacommons_mcp/data_models/observations.py
@@ -113,7 +113,7 @@ class DateRange(BaseModel):
         return self
 
 
-class ObservationToolRequest(BaseModel):
+class ResolvedObservationRequest(BaseModel):
     variable_dcid: str
     place_dcid: str
     child_place_type_dcid: str | None = None
@@ -123,46 +123,91 @@ class ObservationToolRequest(BaseModel):
     child_place_type: str | None = None
 
 
-class SourceMetadata(BaseModel):
-    source_id: str
-    earliest_date: str | None = None
-    latest_date: str | None = None
-    total_observations: int | None = None
-
-
-class Source(Facet):
-    source_id: str
-
-
-class VariableSeries(BaseModel):
-    variable_dcid: str
-    source_metadata: SourceMetadata
-    observations: list[Observation]
-    alternative_sources: list[SourceMetadata] = Field(default_factory=list)
-
-    @property
-    def source_id(self) -> str:
-        """Returns the source_id from the nested source_metadata."""
-        return self.source_metadata.source_id
-
-
-class PlaceData(BaseModel):
-    place_dcid: str = Field(default_factory=str)
-    place_name: str = Field(default_factory=str)
-    variable_series: dict[str, VariableSeries] = Field(default_factory=dict)
-    contained_in: list["PlaceData"] = Field(default_factory=list)
-    place_types: list[str] = Field(default_factory=list)
-
-
 class ObservationApiResponse(ObservationResponse):
     """Wrapper to rename DC Client ObservationResponse to avoid confusion."""
 
 
-class ObservationToolResponse(BaseModel):
-    place_data: dict[str, PlaceData] = Field(
-        default_factory=dict, description="PlaceData objects keyed by their dcid."
+class Source(Facet):
+    """Represents the static metadata for a data source (facet)."""
+
+    source_id: str
+
+
+class SeriesMetadata(BaseModel):
+    """Represents the dynamic metadata for a single series of observations."""
+
+    source_id: str = Field(
+        description="The unique identifier for the data source (facet), used to look up full details in the top-level `source_info`."
     )
+    earliest_date: str | None = None
+    latest_date: str | None = None
+    observation_count: int | None = Field(
+        default=None,
+        description="The total number of observations available from this source, before any date filtering is applied.",
+    )
+
+
+class ResolvedPlace(BaseModel):
+    """Represents a place that was resolved from a name in the request."""
+
+    dcid: str
+    name: str
+    place_type: str | None = Field(
+        default=None,
+        description=(
+            "The specific type of this place (e.g., 'City', 'County'). "
+            "This is especially useful for resolving ambiguity when a query could "
+            "match multiple place types (e.g., 'Sacramento' could be a City or County)."
+        ),
+    )
+
+
+class PlaceObservation(BaseModel):
+    """Contains all observation data for a single place.
+
+    It includes a primary series (with observations), a list of metadata for
+    alternative series, and the specific type of the place (e.g., 'City').
+    """
+
+    place: ResolvedPlace
+
+    # The primary series data
+    primary_series_metadata: SeriesMetadata
+    observations: list[Observation]
+
+    # Metadata for other available sources
+    alternative_series_metadata: list[SeriesMetadata] = Field(default_factory=list)
+
+
+class ObservationToolResponse(BaseModel):
+    """The response from the get_observations tool.
+
+    It contains observation data organized as a list of places. To save tokens,
+    source information is normalized into a top-level `source_info` dictionary.
+    """
+
+    variable_dcid: str
+    variable_name: str | None = None
+
+    resolved_parent_place: ResolvedPlace | None = Field(
+        default=None,
+        description="The parent place that was resolved from the request, if a hierarchical query was made. This confirms how the tool interpreted the `place_name`.",
+    )
+
+    observation_place_type: str | None = Field(
+        default=None,
+        description=(
+            "The common place type for all observations in the response (e.g., 'State', 'County'). "
+            "This is used when all returned places are of the same type to avoid repetition. "
+            "If places are of mixed types, this will be null and the type will be specified in each `PlaceObservation`."
+        ),
+    )
+    observations_by_place: list[PlaceObservation] = Field(
+        default_factory=list,
+        description="A list of observation data, with one entry per place.",
+    )
+
     source_info: dict[str, Source] = Field(
         default_factory=dict,
-        description="Source objects keyed by their source_id.",
+        description="A dictionary of all data sources, keyed by source_id. This avoids data repetition.",
     )

--- a/packages/datacommons-mcp/datacommons_mcp/data_models/observations.py
+++ b/packages/datacommons-mcp/datacommons_mcp/data_models/observations.py
@@ -27,6 +27,9 @@ from pydantic import BaseModel, Field, model_validator
 # Wrapper to rename datacommons_client object to avoid confusion.
 ObservationPeriod = ObservationDate
 
+# Wrapper to rename datacommons_client ObservationResponse to avoid confusion.
+ObservationApiResponse = ObservationResponse
+
 
 class DateRange(BaseModel):
     "Accepted formats: YYYY or YYYY-MM or YYYY-MM-DD"
@@ -152,10 +155,6 @@ class PlaceData(BaseModel):
     variable_series: dict[str, VariableSeries] = Field(default_factory=dict)
     contained_in: list["PlaceData"] = Field(default_factory=list)
     place_types: list[str] = Field(default_factory=list)
-
-
-class ObservationApiResponse(ObservationResponse):
-    """Wrapper to rename DC Client ObservationResponse to avoid confusion."""
 
 
 class ObservationToolResponse(BaseModel):

--- a/packages/datacommons-mcp/datacommons_mcp/data_models/search.py
+++ b/packages/datacommons-mcp/datacommons_mcp/data_models/search.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, Field
 
 class SearchMode(str, Enum):
     """Enumeration of search modes for the search_indicators tool."""
-    
+
     BROWSE = "browse"
     LOOKUP = "lookup"
 
@@ -23,40 +23,60 @@ SearchModeType = Literal["browse", "lookup"]
 
 class SearchTask(BaseModel):
     """Represents a single search task with query and place filters."""
-    
+
     query: str = Field(description="The search query string")
-    place_dcids: list[str] = Field(default_factory=list, description="List of place DCIDs to filter by")
+    place_dcids: list[str] = Field(
+        default_factory=list, description="List of place DCIDs to filter by"
+    )
 
 
 class SearchVariable(BaseModel):
     """Represents a variable object in search results."""
-    
+
     dcid: str = Field(description="Variable DCID")
-    places_with_data: list[str] = Field(default_factory=list, description="Place DCIDs where data exists")
+    places_with_data: list[str] = Field(
+        default_factory=list, description="Place DCIDs where data exists"
+    )
 
 
 class SearchTopic(BaseModel):
     """Represents a topic object in search results."""
-    
+
     dcid: str = Field(description="Topic DCID")
-    member_topics: list[str] = Field(default_factory=list, description="Direct member topic DCIDs")
-    member_variables: list[str] = Field(default_factory=list, description="Direct member variable DCIDs")
-    places_with_data: list[str] | None = Field(None, description="Place DCIDs where data exists (if place filtering was performed)")
+    member_topics: list[str] = Field(
+        default_factory=list, description="Direct member topic DCIDs"
+    )
+    member_variables: list[str] = Field(
+        default_factory=list, description="Direct member variable DCIDs"
+    )
+    places_with_data: list[str] | None = Field(
+        None,
+        description="Place DCIDs where data exists (if place filtering was performed)",
+    )
 
 
 class SearchResult(BaseModel):
     """Represents intermediate results from DCClient."""
-    
-    topics: dict[str, SearchTopic] = Field(default_factory=dict, description="Map of topic DCID to SearchTopic")
-    variables: dict[str, SearchVariable] = Field(default_factory=dict, description="Map of variable DCID to SearchVariable")
+
+    topics: dict[str, SearchTopic] = Field(
+        default_factory=dict, description="Map of topic DCID to SearchTopic"
+    )
+    variables: dict[str, SearchVariable] = Field(
+        default_factory=dict, description="Map of variable DCID to SearchVariable"
+    )
 
 
 class SearchResponse(BaseModel):
-    """Unified response model for search operations.
-    """
-    
-    topics: list[SearchTopic] | None = Field(None, description="List of topic objects (browse mode only)")
-    variables: list[SearchVariable] = Field(description="List of variable objects with dcid and places_with_data")
-    lookups: dict[str, str] = Field(default_factory=dict, description="DCID to name mappings")
-    
+    """Unified response model for search operations."""
+
+    topics: list[SearchTopic] | None = Field(
+        None, description="List of topic objects (browse mode only)"
+    )
+    variables: list[SearchVariable] = Field(
+        description="List of variable objects with dcid and places_with_data"
+    )
+    lookups: dict[str, str] = Field(
+        default_factory=dict, description="DCID to name mappings"
+    )
+
     status: str = Field(default="SUCCESS", description="Status of the search operation")

--- a/packages/datacommons-mcp/datacommons_mcp/data_models/search.py
+++ b/packages/datacommons-mcp/datacommons_mcp/data_models/search.py
@@ -7,6 +7,7 @@ and results used in the search_indicators functionality.
 
 from enum import Enum
 from typing import Literal
+
 from pydantic import BaseModel, Field
 
 

--- a/packages/datacommons-mcp/datacommons_mcp/data_models/settings.py
+++ b/packages/datacommons-mcp/datacommons_mcp/data_models/settings.py
@@ -15,115 +15,103 @@
 Pydantic settings for configuring the MCP server.
 """
 
-import os
-from typing import Union, Literal
+from typing import Any, Literal
+
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings
 
 from .enums import SearchScope
 
-_MODEL_CONFIG = {
-    "env_file": ".env",
-    "extra": "ignore"
-}
+_MODEL_CONFIG = {"env_file": ".env", "extra": "ignore"}
 
 
 class DCSettingsSelector(BaseSettings):
     """Settings selector to determine DC type from environment."""
-    
+
     model_config = _MODEL_CONFIG
-    
+
     dc_type: Literal["base", "custom"] = Field(
-        default="base",
-        alias="DC_TYPE",
-        description="Type of Data Commons"
+        default="base", alias="DC_TYPE", description="Type of Data Commons"
     )
 
 
 class BaseDCSettings(BaseSettings):
     """Settings for base Data Commons instance."""
-    
+
     model_config = _MODEL_CONFIG
-    
-    def __init__(self, **kwargs):
+
+    def __init__(self, **kwargs: dict[str, Any]) -> None:
         super().__init__(**kwargs)
-    
+
     dc_type: Literal["base"] = Field(
         default="base",
         alias="DC_TYPE",
-        description="Type of Data Commons (must be 'base')"
+        description="Type of Data Commons (must be 'base')",
     )
-    api_key: str = Field(
-        alias="DC_API_KEY",
-        description="API key for Data Commons"
-    )
+    api_key: str = Field(alias="DC_API_KEY", description="API key for Data Commons")
     sv_search_base_url: str = Field(
         default="https://datacommons.org",
         alias="DC_SV_SEARCH_BASE_URL",
-        description="Search base URL for base DC"
+        description="Search base URL for base DC",
     )
     base_index: str = Field(
         default="base_uae_mem",
         alias="DC_BASE_INDEX",
-        description="Search index for base DC"
+        description="Search index for base DC",
     )
     topic_cache_path: str | None = Field(
         default=None,
         alias="DC_TOPIC_CACHE_PATH",
-        description="Path to topic cache file"
+        description="Path to topic cache file",
     )
 
 
 class CustomDCSettings(BaseSettings):
     """Settings for custom Data Commons instance."""
-    
+
     model_config = _MODEL_CONFIG
-    
-    def __init__(self, **kwargs):
+
+    def __init__(self, **kwargs: dict[str, Any]) -> None:
         super().__init__(**kwargs)
-    
+
     dc_type: Literal["custom"] = Field(
         default="custom",
         alias="DC_TYPE",
-        description="Type of Data Commons (must be 'custom')"
+        description="Type of Data Commons (must be 'custom')",
     )
-    api_key: str = Field(
-        alias="DC_API_KEY",
-        description="API key for Data Commons"
-    )
+    api_key: str = Field(alias="DC_API_KEY", description="API key for Data Commons")
     custom_dc_url: str = Field(
-        alias="CUSTOM_DC_URL",
-        description="Base URL for custom Data Commons instance"
+        alias="CUSTOM_DC_URL", description="Base URL for custom Data Commons instance"
     )
     api_base_url: str | None = Field(
         default=None,
         alias="DC_API_BASE_URL",
-        description="API base URL (computed from base_url if not provided)"
+        description="API base URL (computed from base_url if not provided)",
     )
     search_scope: SearchScope = Field(
         default=SearchScope.BASE_AND_CUSTOM,
         alias="DC_SEARCH_SCOPE",
-        description="Search scope for queries"
+        description="Search scope for queries",
     )
     base_index: str = Field(
         default="medium_ft",
         alias="DC_BASE_INDEX",
-        description="Search index for base DC"
+        description="Search index for base DC",
     )
     custom_index: str = Field(
         default="user_all_minilm_mem",
         alias="DC_CUSTOM_INDEX",
-        description="Search index for custom DC"
+        description="Search index for custom DC",
     )
     root_topic_dcids: list[str] | None = Field(
         default=None,
         alias="DC_ROOT_TOPIC_DCIDS",
-        description="List of root topic DCIDs"
+        description="List of root topic DCIDs",
     )
-    
-    @field_validator('root_topic_dcids', mode='before')
+
+    @field_validator("root_topic_dcids", mode="before")
     @classmethod
-    def parse_root_topic_dcids(cls, v):
+    def parse_root_topic_dcids(cls, v: str) -> str | None:
         """Parse comma-separated string into list of strings."""
         if isinstance(v, str):
             if not v.strip():
@@ -133,9 +121,9 @@ class CustomDCSettings(BaseSettings):
             # Filter out empty items
             return [item for item in items if item]
         return v
-    
-    @model_validator(mode='after')
-    def compute_api_base_url(self) -> 'CustomDCSettings':
+
+    @model_validator(mode="after")
+    def compute_api_base_url(self) -> "CustomDCSettings":
         """Compute api_base_url from custom_dc_url if not provided."""
         if self.api_base_url is None:
             self.api_base_url = self.custom_dc_url.rstrip("/") + "/core/api/v2/"
@@ -143,4 +131,4 @@ class CustomDCSettings(BaseSettings):
 
 
 # Union type for both settings
-DCSettings = Union[BaseDCSettings, CustomDCSettings]
+DCSettings = BaseDCSettings | CustomDCSettings

--- a/packages/datacommons-mcp/datacommons_mcp/exceptions.py
+++ b/packages/datacommons-mcp/datacommons_mcp/exceptions.py
@@ -27,6 +27,10 @@ class NoDataFoundError(_ErrorStrMixin, LookupError):
     """Raised when a query returns no data for a valid input."""
 
 
+class DataLookupError(_ErrorStrMixin, LookupError):
+    """Raised when there is an error during a data lookup operation."""
+
+
 class InvalidDateFormatError(_ErrorStrMixin, ValueError):
     """Raised when a date string has an invalid format."""
 

--- a/packages/datacommons-mcp/datacommons_mcp/server.py
+++ b/packages/datacommons-mcp/datacommons_mcp/server.py
@@ -41,7 +41,7 @@ from datacommons_mcp.services import get_observations as get_observations_servic
 from datacommons_mcp.services import search_indicators as search_indicators_service
 
 # Configure logging
-logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 # Create client based on settings
 try:

--- a/packages/datacommons-mcp/datacommons_mcp/server.py
+++ b/packages/datacommons-mcp/datacommons_mcp/server.py
@@ -45,15 +45,15 @@ logger = logging.getLogger(__name__)
 
 # Create client based on settings
 try:
-  dc_settings = settings.get_dc_settings()
-  logger.info("Loaded DC settings:\n%s", dc_settings.model_dump_json(indent=2))
-  dc_client = create_dc_client(dc_settings)
+    dc_settings = settings.get_dc_settings()
+    logger.info("Loaded DC settings:\n%s", dc_settings.model_dump_json(indent=2))
+    dc_client = create_dc_client(dc_settings)
 except ValueError as e:
-  logger.error("Settings error: %s", e)
-  raise
+    logger.error("Settings error: %s", e)
+    raise
 except Exception as e:
-  logger.error("Failed to create DC client: %s", e)
-  raise
+    logger.error("Failed to create DC client: %s", e)
+    raise
 
 mcp = FastMCP("DC MCP Server")
 
@@ -67,8 +67,9 @@ async def get_observations(
     source_id_override: str | None = None,
     period: str | None = None,
     start_date: str | None = None,
-    end_date: str | None = None) -> ObservationToolResponse:
-  """Fetches observations for a statistical variable from Data Commons.
+    end_date: str | None = None,
+) -> ObservationToolResponse:
+    """Fetches observations for a statistical variable from Data Commons.
 
     This tool can operate in two primary modes:
     1.  **Single Place Mode**: Get data for one specific place (e.g., "Population of California").
@@ -121,21 +122,24 @@ async def get_observations(
       2.  **Extract Data**: The data is inside `data['data_by_variable']`. Each key is a `variable_id`. The `observations` list contains the actual data points: `[entity_id, date, value]`.
       3.  **Make it Readable**: Use the `data['lookups']['id_name_mappings']` dictionary to convert `variable_id` and `entity_id` from cryptic IDs to human-readable names.
     """
-  return await get_observations_service(client=dc_client,
-                                        variable_dcid=variable_dcid,
-                                        place_dcid=place_dcid,
-                                        place_name=place_name,
-                                        child_place_type=child_place_type,
-                                        source_id_override=source_id_override,
-                                        period=period,
-                                        start_date=start_date,
-                                        end_date=end_date)
+    return await get_observations_service(
+        client=dc_client,
+        variable_dcid=variable_dcid,
+        place_dcid=place_dcid,
+        place_name=place_name,
+        child_place_type=child_place_type,
+        source_id_override=source_id_override,
+        period=period,
+        start_date=start_date,
+        end_date=end_date,
+    )
 
 
 @mcp.tool()
 async def validate_child_place_types(
-    parent_place_name: str, child_place_types: list[str]) -> dict[str, bool]:
-  """
+    parent_place_name: str, child_place_types: list[str]
+) -> dict[str, bool]:
+    """
     Checks which of the child place types are valid for the parent place.
 
     Use this tool to validate the child place types before calling get_observations for those places.
@@ -176,21 +180,22 @@ async def validate_child_place_types(
     Returns:
         A dictionary mapping child place types to a boolean indicating whether they are valid for the parent place.
     """
-  places = await dc_client.search_places([parent_place_name])
-  place_dcid = places.get(parent_place_name, "")
-  if not place_dcid:
-    return dict.fromkeys(child_place_types, False)
+    places = await dc_client.search_places([parent_place_name])
+    place_dcid = places.get(parent_place_name, "")
+    if not place_dcid:
+        return dict.fromkeys(child_place_types, False)
 
-  tasks = [
-      dc_client.child_place_type_exists(
-          place_dcid,
-          child_place_type,
-      ) for child_place_type in child_place_types
-  ]
+    tasks = [
+        dc_client.child_place_type_exists(
+            place_dcid,
+            child_place_type,
+        )
+        for child_place_type in child_place_types
+    ]
 
-  results = await asyncio.gather(*tasks)
+    results = await asyncio.gather(*tasks)
 
-  return dict(zip(child_place_types, results, strict=False))
+    return dict(zip(child_place_types, results, strict=False))
 
 
 @mcp.tool()
@@ -202,7 +207,7 @@ async def get_datacommons_chart_config(
     parent_place_dcid: str | None = None,
     child_place_type: str | None = None,
 ) -> DataCommonsChartConfig:
-  """Constructs and validates a DataCommons chart configuration.
+    """Constructs and validates a DataCommons chart configuration.
 
     This unified factory function serves as a robust constructor for creating
     any type of DataCommons chart configuration from primitive inputs. It uses a
@@ -273,75 +278,77 @@ async def get_datacommons_chart_config(
             - If any inputs fail Pydantic's model validation for the target
               chart configuration.
     """
-  # Validate chart_type param
-  chart_config_class = CHART_CONFIG_MAP.get(chart_type)
-  if not chart_config_class:
-    raise ValueError(
-        f"Invalid chart_type: '{chart_type}'. Valid types are: {list(CHART_CONFIG_MAP.keys())}"
-    )
+    # Validate chart_type param
+    chart_config_class = CHART_CONFIG_MAP.get(chart_type)
+    if not chart_config_class:
+        raise ValueError(
+            f"Invalid chart_type: '{chart_type}'. Valid types are: {list(CHART_CONFIG_MAP.keys())}"
+        )
 
-  # Validate provided place params
-  if not place_dcids and not (parent_place_dcid and child_place_type):
-    raise ValueError(
-        "Supply either a list of place_dcids or a single parent_dcid-child_place_type pair."
-    )
-  if place_dcids and (parent_place_dcid or child_place_type):
-    raise ValueError(
-        "Provide either 'place_dcids' or a 'parent_dcid'/'child_place_type' pair, but not both."
-    )
+    # Validate provided place params
+    if not place_dcids and not (parent_place_dcid and child_place_type):
+        raise ValueError(
+            "Supply either a list of place_dcids or a single parent_dcid-child_place_type pair."
+        )
+    if place_dcids and (parent_place_dcid or child_place_type):
+        raise ValueError(
+            "Provide either 'place_dcids' or a 'parent_dcid'/'child_place_type' pair, but not both."
+        )
 
-  # Validate variable params
-  if not variable_dcids:
-    raise ValueError("At least one variable_dcid is required.")
+    # Validate variable params
+    if not variable_dcids:
+        raise ValueError("At least one variable_dcid is required.")
 
-  # 2. Intelligently construct the location object based on the input
-  #    This part makes some assumptions based on the provided signature.
-  #    For single-place charts, we use the first DCID. For multi-place, we use all.
-  try:
-    location_model = chart_config_class.model_fields["location"].annotation
-    location_obj = None
+    # 2. Intelligently construct the location object based on the input
+    #    This part makes some assumptions based on the provided signature.
+    #    For single-place charts, we use the first DCID. For multi-place, we use all.
+    try:
+        location_model = chart_config_class.model_fields["location"].annotation
+        location_obj = None
 
-    # Check if the annotation is a Union (e.g., Union[A, B] or A | B)
-    if get_origin(location_model) in (Union, types.UnionType):
-      # Get the types inside the Union
-      # e.g., (SinglePlaceLocation, MultiPlaceLocation)
-      possible_location_types = get_args(location_model)
-    else:
-      possible_location_types = [location_model]
+        # Check if the annotation is a Union (e.g., Union[A, B] or A | B)
+        if get_origin(location_model) in (Union, types.UnionType):
+            # Get the types inside the Union
+            # e.g., (SinglePlaceLocation, MultiPlaceLocation)
+            possible_location_types = get_args(location_model)
+        else:
+            possible_location_types = [location_model]
 
-    # Now, check if our desired types are possible options
-    if MultiPlaceLocation in possible_location_types and place_dcids:
-      # Prioritize MultiPlaceLocation if multiple places are given
-      location_obj = MultiPlaceLocation(place_dcids=place_dcids)
-    elif SinglePlaceLocation in possible_location_types and place_dcids:
-      # Fall back to SinglePlaceLocation if it's an option
-      location_obj = SinglePlaceLocation(place_dcid=place_dcids[0])
-    elif HierarchyLocation in possible_location_types and (parent_place_dcid and
-                                                           child_place_type):
-      location_obj = HierarchyLocation(parent_place_dcid=parent_place_dcid,
-                                       child_place_type=child_place_type)
-    else:
-      # The Union doesn't contain a type we can build
-      raise ValueError(
-          f"Chart type '{chart_type}' requires a location type "
-          f"('{location_model.__name__}') that this function cannot build from "
-          "the provided args.")
+        # Now, check if our desired types are possible options
+        if MultiPlaceLocation in possible_location_types and place_dcids:
+            # Prioritize MultiPlaceLocation if multiple places are given
+            location_obj = MultiPlaceLocation(place_dcids=place_dcids)
+        elif SinglePlaceLocation in possible_location_types and place_dcids:
+            # Fall back to SinglePlaceLocation if it's an option
+            location_obj = SinglePlaceLocation(place_dcid=place_dcids[0])
+        elif HierarchyLocation in possible_location_types and (
+            parent_place_dcid and child_place_type
+        ):
+            location_obj = HierarchyLocation(
+                parent_place_dcid=parent_place_dcid, child_place_type=child_place_type
+            )
+        else:
+            # The Union doesn't contain a type we can build
+            raise ValueError(
+                f"Chart type '{chart_type}' requires a location type "
+                f"('{location_model.__name__}') that this function cannot build from "
+                "the provided args."
+            )
 
-    if issubclass(chart_config_class, SingleVariableChart):
-      return chart_config_class(
-          header=chart_title,
-          location=location_obj,
-          variable_dcid=variable_dcids[0],
-      )
+        if issubclass(chart_config_class, SingleVariableChart):
+            return chart_config_class(
+                header=chart_title,
+                location=location_obj,
+                variable_dcid=variable_dcids[0],
+            )
 
-    return chart_config_class(header=chart_title,
-                              location=location_obj,
-                              variable_dcids=variable_dcids)
+        return chart_config_class(
+            header=chart_title, location=location_obj, variable_dcids=variable_dcids
+        )
 
-  except ValidationError as e:
-    # Catch Pydantic errors and make them more user-friendly
-    raise ValueError(
-        f"Validation failed for chart_type '{chart_type}': {e}") from e
+    except ValidationError as e:
+        # Catch Pydantic errors and make them more user-friendly
+        raise ValueError(f"Validation failed for chart_type '{chart_type}': {e}") from e
 
 
 @mcp.tool()
@@ -352,7 +359,7 @@ async def search_indicators(
     place2_name: str | None = None,
     per_search_limit: int = 10,
 ) -> dict:
-  """Search for topics and variables (collectively called "indicators") across Data Commons.
+    """Search for topics and variables (collectively called "indicators") across Data Commons.
 
     This tool returns candidate indicators that match your query. You should treat these as
     candidates and filter them based on the user's query and context to surface the most
@@ -451,5 +458,6 @@ async def search_indicators(
     - Both modes support place filtering and bilateral queries
     - Both modes use sophisticated query rewriting logic for optimal results
     """
-  return await search_indicators_service(dc_client, query, mode, place1_name,
-                                         place2_name, per_search_limit)
+    return await search_indicators_service(
+        dc_client, query, mode, place1_name, place2_name, per_search_limit
+    )

--- a/packages/datacommons-mcp/datacommons_mcp/server.py
+++ b/packages/datacommons-mcp/datacommons_mcp/server.py
@@ -198,9 +198,6 @@ async def validate_child_place_types(
     return dict(zip(child_place_types, results, strict=False))
 
 
-
-
-
 @mcp.tool()
 async def get_datacommons_chart_config(
     chart_type: str,
@@ -354,9 +351,6 @@ async def get_datacommons_chart_config(
         raise ValueError(f"Validation failed for chart_type '{chart_type}': {e}") from e
 
 
-
-
-
 @mcp.tool()
 async def search_indicators(
     query: str,
@@ -464,7 +458,6 @@ async def search_indicators(
     - Both modes support place filtering and bilateral queries
     - Both modes use sophisticated query rewriting logic for optimal results
     """
-    return await search_indicators_service(dc_client, query, mode, place1_name, place2_name, per_search_limit)
-
-
-
+    return await search_indicators_service(
+        dc_client, query, mode, place1_name, place2_name, per_search_limit
+    )

--- a/packages/datacommons-mcp/datacommons_mcp/server.py
+++ b/packages/datacommons-mcp/datacommons_mcp/server.py
@@ -121,17 +121,15 @@ async def get_observations(
       2.  **Extract Data**: The data is inside `data['data_by_variable']`. Each key is a `variable_id`. The `observations` list contains the actual data points: `[entity_id, date, value]`.
       3.  **Make it Readable**: Use the `data['lookups']['id_name_mappings']` dictionary to convert `variable_id` and `entity_id` from cryptic IDs to human-readable names.
     """
-  return await get_observations_service(
-      client=dc_client,
-      variable_dcid=variable_dcid,
-      place_dcid=place_dcid,
-      place_name=place_name,
-      child_place_type=child_place_type,
-      source_id_override=source_id_override,
-      period=period,
-      start_date=start_date,
-      end_date=end_date,
-  )
+  return await get_observations_service(client=dc_client,
+                                        variable_dcid=variable_dcid,
+                                        place_dcid=place_dcid,
+                                        place_name=place_name,
+                                        child_place_type=child_place_type,
+                                        source_id_override=source_id_override,
+                                        period=period,
+                                        start_date=start_date,
+                                        end_date=end_date)
 
 
 @mcp.tool()

--- a/packages/datacommons-mcp/datacommons_mcp/server.py
+++ b/packages/datacommons-mcp/datacommons_mcp/server.py
@@ -67,8 +67,7 @@ async def get_observations(
     source_id_override: str | None = None,
     period: str | None = None,
     start_date: str | None = None,
-    end_date: str | None = None,
-) -> ObservationToolResponse:
+    end_date: str | None = None) -> ObservationToolResponse:
   """Fetches observations for a statistical variable from Data Commons.
 
     This tool can operate in two primary modes:

--- a/packages/datacommons-mcp/datacommons_mcp/server.py
+++ b/packages/datacommons-mcp/datacommons_mcp/server.py
@@ -52,7 +52,7 @@ try:
     dc_settings = settings.get_dc_settings()
     logger.info("Loaded DC settings:\n%s", dc_settings.model_dump_json(indent=2))
     dc_client = create_dc_client(dc_settings)
-except ValueError as e:
+except ValidationError as e:
     logger.error("Settings error: %s", e)
     raise
 except Exception as e:

--- a/packages/datacommons-mcp/datacommons_mcp/server.py
+++ b/packages/datacommons-mcp/datacommons_mcp/server.py
@@ -36,22 +36,26 @@ from datacommons_mcp.data_models.charts import (
 from datacommons_mcp.data_models.observations import (
     ObservationToolResponse,
 )
-from datacommons_mcp.services import get_observations as get_observations_service, search_topics_and_variables as search_topics_and_variables_service
+from datacommons_mcp.services import (
+    get_observations as get_observations_service,
+)
+from datacommons_mcp.services import (
+    search_topics_and_variables as search_topics_and_variables_service,
+)
 
+logger = logging.getLogger(__name__)
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
 
 # Create client based on settings
 try:
     dc_settings = settings.get_dc_settings()
-    logging.info(f"Loaded DC settings:\n{dc_settings.model_dump_json(indent=2)}")
+    logger.info("Loaded DC settings:\n%s", dc_settings.model_dump_json(indent=2))
     dc_client = create_dc_client(dc_settings)
 except ValueError as e:
-    logging.error(f"Settings error: {e}")
+    logger.error("Settings error: %s", e)
     raise
 except Exception as e:
-    logging.error(f"Failed to create DC client: {e}")
+    logger.error("Failed to create DC client: %s", e)
     raise
 
 mcp = FastMCP("DC MCP Server")
@@ -501,7 +505,6 @@ async def search_topics_and_variables(
     * **Filter and rank**: Treat all results as candidates and filter/rank based on user context.
     * **Data availability**: Use `places_with_data` to understand which places have data for each indicator.
     """
-    return await search_topics_and_variables_service(dc_client, query, place1_name, place2_name, per_search_limit)
-
-
-
+    return await search_topics_and_variables_service(
+        dc_client, query, place1_name, place2_name, per_search_limit
+    )

--- a/packages/datacommons-mcp/datacommons_mcp/services.py
+++ b/packages/datacommons-mcp/datacommons_mcp/services.py
@@ -22,7 +22,7 @@ from datacommons_mcp.data_models.observations import (
     ObservationToolRequest,
     ObservationToolResponse,
 )
-from datacommons_mcp.exceptions import NoDataFoundError
+from datacommons_mcp.exceptions import DataLookupError
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +69,7 @@ async def _build_observation_request(
         results = await client.search_places([place_name])
         place_dcid = results.get(place_name)
     if not place_dcid:
-        raise NoDataFoundError(f"No place found matching '{place_name}'.")
+        raise DataLookupError(f"No place found matching '{place_name}'.")
 
     # 3. Return an instance of the class
     return ObservationToolRequest(
@@ -143,8 +143,9 @@ async def search_topics_and_variables(
         try:
             place_dcids_map = await client.search_places(place_names)
         except Exception as e:
-            logger.error("Error resolving place names: %s", e)
-            raise e
+            msg = "Error resolving place names"
+            logger.error("%s: %s", msg, e)
+            raise DataLookupError(msg) from e
 
     place1_dcid = place_dcids_map.get(place1_name) if place1_name else None
     place2_dcid = place_dcids_map.get(place2_name) if place2_name else None

--- a/packages/datacommons-mcp/datacommons_mcp/services.py
+++ b/packages/datacommons-mcp/datacommons_mcp/services.py
@@ -176,7 +176,8 @@ async def search_indicators(
     if search_mode == SearchMode.LOOKUP and not place_names:
         search_mode = SearchMode.BROWSE
         logger.info(
-            "Lookup mode requested but no places provided. Automatically switching to browse mode for query: %s", query
+            "Lookup mode requested but no places provided. Automatically switching to browse mode for query: %s",
+            query,
         )
 
     # Construct search queries with their corresponding place DCIDs for filtering
@@ -295,9 +296,7 @@ async def _fetch_and_update_lookups(client: DCClient, dcids: list[str]) -> dict:
         return {}
 
 
-async def _merge_search_results(
-    results: list[dict]
-) -> SearchResult:
+async def _merge_search_results(results: list[dict]) -> SearchResult:
     """Union results from multiple search calls."""
 
     # Collect all topics and variables
@@ -369,9 +368,7 @@ async def _search_indicators_lookup_mode(
                     all_variables[var_dcid].places_with_data.append(place_dcid)
 
             except Exception as e:  # noqa: BLE001
-                logger.error(
-                    "Error fetching variables for place %s: %s", place_dcid, e
-                )
+                logger.error("Error fetching variables for place %s: %s", place_dcid, e)
                 continue
 
     # Limit results if needed

--- a/packages/datacommons-mcp/datacommons_mcp/services.py
+++ b/packages/datacommons-mcp/datacommons_mcp/services.py
@@ -192,7 +192,6 @@ async def search_topics_and_variables(
     return await _merge_search_results(results, valid_place_dcids, client)
 
 
-
 def _collect_all_dcids(
     topics: list[dict], variables: list[str], place_dcids: list[str] = None
 ) -> list[str]:

--- a/packages/datacommons-mcp/datacommons_mcp/services.py
+++ b/packages/datacommons-mcp/datacommons_mcp/services.py
@@ -130,7 +130,7 @@ async def search_indicators(
     per_search_limit: int = 10,
 ) -> SearchResponse:
     """Search for topics and/or variables based on mode.
-    
+
     Args:
         client: DCClient instance to use for data operations
         query: The search query for indicators
@@ -138,7 +138,7 @@ async def search_indicators(
         place1_name: First place name for filtering and existence checks
         place2_name: Second place name for filtering and existence checks
         per_search_limit: Maximum results per search (default 10, max 100)
-    
+
     Returns:
         dict: Dictionary with topics, variables, and lookups (browse mode) or variables only (lookup mode)
     """
@@ -149,8 +149,10 @@ async def search_indicators(
         try:
             search_mode = SearchMode(mode)
         except ValueError:
-            raise ValueError(f"mode must be either '{SearchMode.BROWSE.value}' or '{SearchMode.LOOKUP.value}'")
-    
+            raise ValueError(
+                f"mode must be either '{SearchMode.BROWSE.value}' or '{SearchMode.LOOKUP.value}'"
+            )
+
     # Validate per_search_limit parameter
     if not 1 <= per_search_limit <= 100:
         raise ValueError("per_search_limit must be between 1 and 100")
@@ -173,7 +175,9 @@ async def search_indicators(
     # Automatic fallback to browse mode if lookup mode is requested but no places are provided
     if search_mode == SearchMode.LOOKUP and not place_names:
         search_mode = SearchMode.BROWSE
-        logging.info(f"Lookup mode requested but no places provided. Automatically switching to browse mode for query: {query}")
+        logging.info(
+            f"Lookup mode requested but no places provided. Automatically switching to browse mode for query: {query}"
+        )
 
     # Construct search queries with their corresponding place DCIDs for filtering
     search_tasks = []
@@ -189,11 +193,21 @@ async def search_indicators(
 
     # Place1 query: search for query + place1_name, filter by place2_dcid
     if place1_dcid:
-        search_tasks.append(SearchTask(query=f"{query} {place1_name}", place_dcids=[place2_dcid] if place2_dcid else []))
+        search_tasks.append(
+            SearchTask(
+                query=f"{query} {place1_name}",
+                place_dcids=[place2_dcid] if place2_dcid else [],
+            )
+        )
 
     # Place2 query: search for query + place2_name, filter by place1_dcid
     if place2_dcid:
-        search_tasks.append(SearchTask(query=f"{query} {place2_name}", place_dcids=[place1_dcid] if place1_dcid else []))
+        search_tasks.append(
+            SearchTask(
+                query=f"{query} {place2_name}",
+                place_dcids=[place1_dcid] if place1_dcid else [],
+            )
+        )
 
     if search_mode == SearchMode.LOOKUP:
         # For lookup mode, use simplified logic with query rewriting
@@ -205,33 +219,35 @@ async def search_indicators(
         search_result = await _search_indicators_browse_mode(
             client, search_tasks, per_search_limit
         )
-    
+
     # Collect all DCIDs for lookups
     all_dcids = set()
-    
+
     # Add topic DCIDs and their members
     for topic in search_result.topics.values():
         all_dcids.add(topic.dcid)
         all_dcids.update(topic.member_topics)
         all_dcids.update(topic.member_variables)
-    
+
     # Add variable DCIDs
     all_dcids.update(search_result.variables.keys())
-    
+
     # Add place DCIDs
     all_place_dcids = set()
     for search_task in search_tasks:
         all_place_dcids.update(search_task.place_dcids)
     all_dcids.update(all_place_dcids)
-    
+
     # Fetch lookups
     lookups = await _fetch_and_update_lookups(client, list(all_dcids))
-    
+
     # Create unified response
     return SearchResponse(
         status="SUCCESS",
         lookups=lookups,
-        topics=list(search_result.topics.values()) if search_mode == SearchMode.BROWSE else None,
+        topics=list(search_result.topics.values())
+        if search_mode == SearchMode.BROWSE
+        else None,
         variables=list(search_result.variables.values()),
     )
 
@@ -255,7 +271,9 @@ async def _search_indicators_browse_mode(
     tasks = []
     for search_task in search_tasks:
         task = client.fetch_topics_and_variables(
-            query=search_task.query, place_dcids=search_task.place_dcids, max_results=per_search_limit
+            query=search_task.query,
+            place_dcids=search_task.place_dcids,
+            max_results=per_search_limit,
         )
         tasks.append(task)
 
@@ -268,13 +286,10 @@ async def _search_indicators_browse_mode(
     for search_task in search_tasks:
         all_place_dcids.update(search_task.place_dcids)
     valid_place_dcids = list(all_place_dcids)
-    
+
     merged_result = await _merge_search_results(results, valid_place_dcids, client)
 
     return merged_result
-
-
-
 
 
 async def _fetch_and_update_lookups(client: DCClient, dcids: list[str]) -> dict:
@@ -307,7 +322,7 @@ async def _merge_search_results(
                     dcid=topic["dcid"],
                     member_topics=topic.get("member_topics", []),
                     member_variables=topic.get("member_variables", []),
-                    places_with_data=topic.get("places_with_data")
+                    places_with_data=topic.get("places_with_data"),
                 )
 
         # Union variables
@@ -316,13 +331,10 @@ async def _merge_search_results(
             if var_dcid not in all_variables:
                 all_variables[var_dcid] = SearchVariable(
                     dcid=variable["dcid"],
-                    places_with_data=variable.get("places_with_data", [])
+                    places_with_data=variable.get("places_with_data", []),
                 )
 
-    return SearchResult(
-        topics=all_topics,
-        variables=all_variables
-    )
+    return SearchResult(topics=all_topics, variables=all_variables)
 
 
 async def _search_indicators_lookup_mode(
@@ -331,43 +343,44 @@ async def _search_indicators_lookup_mode(
     per_search_limit: int = 10,
 ) -> SearchResult:
     """Search for variables only in lookup mode with query rewriting.
-    
+
     Args:
         client: DCClient instance to use for data operations
         search_tasks: List of SearchTask objects for parallel searches
         per_search_limit: Maximum results per search (default 10, max 100)
-    
+
     Returns:
         SearchResult: Typed result with variables dictionary only
     """
     # Execute parallel searches for each query/place combination
-    all_variables: dict[str, SearchVariable] = {}  # Map of variable_dcid -> SearchVariable
+    all_variables: dict[
+        str, SearchVariable
+    ] = {}  # Map of variable_dcid -> SearchVariable
     all_place_dcids = set()
 
     for search_task in search_tasks:
         all_place_dcids.update(search_task.place_dcids)
-        
+
         # For each place, search for variables
         for place_dcid in search_task.place_dcids:
             try:
                 variable_data = await client.fetch_topic_variables(
                     place_dcid, topic_query=search_task.query
                 )
-                
+
                 # Extract variable DCIDs and track which place found each variable
                 variable_dcids = variable_data.get("topic_variable_ids", [])
                 for var_dcid in variable_dcids:
                     if var_dcid not in all_variables:
                         all_variables[var_dcid] = SearchVariable(
-                            dcid=var_dcid,
-                            places_with_data=[]
+                            dcid=var_dcid, places_with_data=[]
                         )
                     all_variables[var_dcid].places_with_data.append(place_dcid)
-                
+
             except Exception as e:
                 logging.error(f"Error fetching variables for place {place_dcid}: {e}")
                 continue
-    
+
     # Limit results if needed
     if per_search_limit and len(all_variables) > per_search_limit:
         # Convert to list, limit, then back to dict
@@ -380,8 +393,5 @@ async def _search_indicators_lookup_mode(
 
     return SearchResult(
         topics={},  # No topics in lookup mode
-        variables=all_variables
+        variables=all_variables,
     )
-
-
-

--- a/packages/datacommons-mcp/datacommons_mcp/settings.py
+++ b/packages/datacommons-mcp/datacommons_mcp/settings.py
@@ -15,28 +15,31 @@
 Settings module for Data Commons clients.
 """
 
-from .data_models.settings import BaseDCSettings, CustomDCSettings, DCSettings, DCSettingsSelector
+from .data_models.settings import (
+    BaseDCSettings,
+    CustomDCSettings,
+    DCSettings,
+    DCSettingsSelector,
+)
 
 
 def get_dc_settings() -> DCSettings:
     """
     Get Data Commons settings from environment variables.
-    
+
     Automatically loads from .env file if present.
-    
+
     Returns:
         DCSettings object containing the configuration
-        
+
     Raises:
         ValueError: If required configuration is missing or invalid
     """
 
-    
     # First, determine the DC type using the settings selector
     settings_selector = DCSettingsSelector()
-    
+
     # Create the appropriate settings class based on the type
     if settings_selector.dc_type == "custom":
         return CustomDCSettings()
-    else:
-        return BaseDCSettings()
+    return BaseDCSettings()

--- a/packages/datacommons-mcp/datacommons_mcp/topics.py
+++ b/packages/datacommons-mcp/datacommons_mcp/topics.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 
 import json
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Set
 
 from datacommons_client.client import DataCommonsClient
+
+logger = logging.getLogger(__name__)
 
 # Constants
 _SOURCE_DIR = Path(__file__).resolve().parent
@@ -58,19 +60,11 @@ class TopicNodeData:
 
     def get_variables(self) -> list[str]:
         """Extract variable DCIDs from relevant_variables."""
-        variables = []
-        for var in self.relevant_variables:
-            if not _is_topic_dcid(var):
-                variables.append(var)
-        return variables
+        return [var for var in self.relevant_variables  if not _is_topic_dcid(var)]
 
     def get_member_topics(self) -> list[str]:
         """Extract topic DCIDs from relevant_variables."""
-        topics = []
-        for var in self.relevant_variables:
-            if _is_topic_dcid(var):
-                topics.append(var)
-        return topics
+        return [var for var in self.relevant_variables if _is_topic_dcid(var)]
 
     def get_variable_names(self) -> dict[str, str]:
         """Get the mapping of variable DCIDs to their names."""
@@ -204,8 +198,8 @@ def read_topic_cache(file_path: Path = _DEFAULT_TOPIC_CACHE_PATH) -> TopicStore:
 
 
 def _fetch_node_data(
-    topic_dcids: List[str], dc_client: DataCommonsClient
-) -> Dict[str, TopicNodeData]:
+    topic_dcids: list[str], dc_client: DataCommonsClient
+) -> dict[str, TopicNodeData]:
     """
     Fetch node data for the given topic DCIDs using DataCommonsClient.
 
@@ -252,7 +246,7 @@ def _fetch_node_data(
 
         return nodes_by_dcid
     except Exception as e:
-        print(f"Error fetching node data: {e}")
+        logger.error("Error fetching node data: %s", e)
         return {}
 
 
@@ -323,11 +317,14 @@ def _load_topic_store_from_cache(cache_file_path: Path) -> TopicStore:
 
     # Note: Cached data now only contains direct variables
     # Descendant variables are computed on-demand during existence checks
-    print(f"Loaded topic store from cache with {len(topics_by_dcid)} topics")
+    logger.info("Loaded topic store from cache with %s topics", len(topics_by_dcid))
     for topic_dcid in topics_by_dcid:
         topic_data = topics_by_dcid[topic_dcid]
-        print(
-            f"  Topic {topic_dcid}: {len(topic_data.variables)} direct variables, {len(topic_data.member_topics)} member topics"
+        logger.info(
+            "  Topic %s: %s direct variables, %s member topics",
+            topic_dcid,
+            len(topic_data.variables),
+            len(topic_data.member_topics),
         )
 
     return TopicStore(
@@ -338,7 +335,7 @@ def _load_topic_store_from_cache(cache_file_path: Path) -> TopicStore:
 
 
 def create_topic_store(
-    root_topic_dcids: List[str],
+    root_topic_dcids: list[str],
     dc_client: DataCommonsClient,
     cache_file_path: Path | None = None,
 ) -> TopicStore:
@@ -357,18 +354,18 @@ def create_topic_store(
     # Try to load from cache first
     if cache_file_path and cache_file_path.exists():
         try:
-            print(f"Loading topic store from cache: {cache_file_path}")
+            logger.info("Loading topic store from cache: %s", cache_file_path)
             return _load_topic_store_from_cache(cache_file_path)
         except Exception as e:
-            print(f"Failed to load from cache: {e}")
-            print("Falling back to API fetch...")
+            logger.warning("Failed to load from cache: %s", e)
+            logger.warning("Falling back to API fetch...")
 
     # Fetch from API
-    topics_by_dcid: Dict[str, TopicVariables] = {}
-    all_variables: Set[str] = set()
-    dcid_to_name: Dict[str, str] = {}
-    visited_topics: Set[str] = set()
-    topics_to_fetch: Set[str] = set(root_topic_dcids)
+    topics_by_dcid: dict[str, TopicVariables] = {}
+    all_variables: set[str] = set()
+    dcid_to_name: dict[str, str] = {}
+    visited_topics: set[str] = set()
+    topics_to_fetch: set[str] = set(root_topic_dcids)
 
     while topics_to_fetch:
         # Fetch data for current batch of topics
@@ -420,11 +417,14 @@ def create_topic_store(
 
     # Note: We now only store direct variables in TopicVariables.variables
     # Descendant variables are computed on-demand during existence checks
-    print(f"Created topic store with {len(topics_by_dcid)} topics")
+    logger.info("Created topic store with %s topics", len(topics_by_dcid))
     for topic_dcid in topics_by_dcid:
         topic_data = topics_by_dcid[topic_dcid]
-        print(
-            f"  Topic {topic_dcid}: {len(topic_data.variables)} direct variables, {len(topic_data.member_topics)} member topics"
+        logger.info(
+            "  Topic %s: %s direct variables, %s member topics",
+            topic_dcid,
+            len(topic_data.variables),
+            len(topic_data.member_topics),
         )
 
     topic_store = TopicStore(
@@ -436,9 +436,9 @@ def create_topic_store(
     # Cache the result if a cache file path is provided
     if cache_file_path:
         try:
-            print(f"Caching topic store to: {cache_file_path}")
+            logger.info("Caching topic store to: %s", cache_file_path)
             _save_topic_store_to_cache(topic_store, cache_file_path)
         except Exception as e:
-            print(f"Failed to cache topic store: {e}")
+            logger.error("Failed to cache topic store: %s", e)
 
     return topic_store

--- a/packages/datacommons-mcp/datacommons_mcp/topics.py
+++ b/packages/datacommons-mcp/datacommons_mcp/topics.py
@@ -60,7 +60,7 @@ class TopicNodeData:
 
     def get_variables(self) -> list[str]:
         """Extract variable DCIDs from relevant_variables."""
-        return [var for var in self.relevant_variables  if not _is_topic_dcid(var)]
+        return [var for var in self.relevant_variables if not _is_topic_dcid(var)]
 
     def get_member_topics(self) -> list[str]:
         """Extract topic DCIDs from relevant_variables."""

--- a/packages/datacommons-mcp/docs/dev.md
+++ b/packages/datacommons-mcp/docs/dev.md
@@ -146,6 +146,17 @@ uv sync && uv run pre-commit install --hook-type pre-push # Configures pre-commi
 ```
 Note, this command must be re-run every time `.pre-commit-config.yaml` is updated.
 
+To get the pre-commit command line tool to run without the presence of `.pre-commit-config.yaml`, run:
+```bash
+export PRE_COMMIT_ALLOW_NO_CONFIG=1
+```
+
+To bypass the pre-push hooks and push to branch, use the --no-verify flag. For example:
+```bash
+git push origin $BRANCH --no-verify
+```
+
+
 ## Publishing a New Version
 
 To publish a new version of `datacommons-mcp` to [PyPI](https://pypi.org/project/datacommons-mcp):

--- a/packages/datacommons-mcp/docs/dev.md
+++ b/packages/datacommons-mcp/docs/dev.md
@@ -4,6 +4,12 @@ A MCP server for fetching statistical data from Data Commons instances.
 
 ## Development
 
+### One time setup
+
+```bash
+uv sync && uv run pre-commit install --hook-type pre-push # Configures pre-commit hooks for formatting repo prior to push
+```
+
 ### Start MCP locally
 
 Option 1: Use the datacommons-mcp cli

--- a/packages/datacommons-mcp/docs/dev.md
+++ b/packages/datacommons-mcp/docs/dev.md
@@ -4,11 +4,6 @@ A MCP server for fetching statistical data from Data Commons instances.
 
 ## Development
 
-### One time setup
-
-```bash
-uv sync && uv run pre-commit install --hook-type pre-push # Configures pre-commit hooks for formatting repo prior to push
-```
 
 ### Start MCP locally
 
@@ -143,6 +138,13 @@ uv run ruff check # to check files
 
 uv run ruff format # to format files
 ```
+
+# Pre Push Hook
+To install a pre push hook for auto formatting and pytesting, run:
+```bash
+uv sync && uv run pre-commit install --hook-type pre-push # Configures pre-commit hooks for formatting repo prior to push
+```
+Note, this command must be re-run every time `.pre-commit-config.yaml` is updated.
 
 ## Publishing a New Version
 

--- a/packages/datacommons-mcp/docs/dev.md
+++ b/packages/datacommons-mcp/docs/dev.md
@@ -146,11 +146,6 @@ uv sync && uv run pre-commit install --hook-type pre-push # Configures pre-commi
 ```
 Note, this command must be re-run every time `.pre-commit-config.yaml` is updated.
 
-To get the pre-commit command line tool to run without the presence of `.pre-commit-config.yaml`, run:
-```bash
-export PRE_COMMIT_ALLOW_NO_CONFIG=1
-```
-
 To bypass the pre-push hooks and push to branch, use the --no-verify flag. For example:
 ```bash
 git push origin $BRANCH --no-verify

--- a/packages/datacommons-mcp/tests/test_dc_client.py
+++ b/packages/datacommons-mcp/tests/test_dc_client.py
@@ -23,16 +23,11 @@ without making actual network calls.
 
 import os
 from unittest.mock import AsyncMock, Mock, patch
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from unittest.mock import Mock as MockType
 
 import pytest
 from datacommons_client.client import DataCommonsClient
 from datacommons_mcp.clients import DCClient, create_dc_client
 from datacommons_mcp.data_models.enums import SearchScope
-from datacommons_mcp.data_models.settings import BaseDCSettings, CustomDCSettings
 from datacommons_mcp.data_models.observations import (
     DateRange,
     ObservationApiResponse,
@@ -44,6 +39,7 @@ from datacommons_mcp.data_models.observations import (
     SourceMetadata,
     VariableSeries,
 )
+from datacommons_mcp.data_models.settings import BaseDCSettings, CustomDCSettings
 
 
 @pytest.fixture
@@ -91,7 +87,7 @@ class TestDCClientConstructor:
             dc=mocked_datacommons_client,
             search_scope=SearchScope.CUSTOM_ONLY,
             base_index="medium_ft",
-            custom_index="user_all_minilm_mem"
+            custom_index="user_all_minilm_mem",
         )
 
         # Assert: Verify the client is configured correctly
@@ -110,35 +106,45 @@ class TestDCClientConstructor:
             dc=mocked_datacommons_client,
             search_scope=SearchScope.BASE_AND_CUSTOM,
             base_index="medium_ft",
-            custom_index="user_all_minilm_mem"
+            custom_index="user_all_minilm_mem",
         )
 
         # Assert: Verify the client is configured correctly
         assert client_under_test.search_scope == SearchScope.BASE_AND_CUSTOM
         assert client_under_test.search_indices == ["user_all_minilm_mem", "medium_ft"]
 
-    def test_compute_search_indices_validation_custom_only_without_index(self, mocked_datacommons_client):
+    def test_compute_search_indices_validation_custom_only_without_index(
+        self, mocked_datacommons_client
+    ):
         """
         Test that CUSTOM_ONLY search scope without custom_index raises ValueError.
         """
         # Arrange & Act & Assert: Creating client with invalid configuration should raise ValueError
-        with pytest.raises(ValueError, match="Custom index not configured but CUSTOM_ONLY search scope requested"):
+        with pytest.raises(
+            ValueError,
+            match="Custom index not configured but CUSTOM_ONLY search scope requested",
+        ):
             DCClient(
                 dc=mocked_datacommons_client,
                 search_scope=SearchScope.CUSTOM_ONLY,
-                custom_index=None
+                custom_index=None,
             )
 
-    def test_compute_search_indices_validation_custom_only_with_empty_index(self, mocked_datacommons_client):
+    def test_compute_search_indices_validation_custom_only_with_empty_index(
+        self, mocked_datacommons_client
+    ):
         """
         Test that CUSTOM_ONLY search scope with empty custom_index raises ValueError.
         """
         # Arrange & Act & Assert: Creating client with invalid configuration should raise ValueError
-        with pytest.raises(ValueError, match="Custom index not configured but CUSTOM_ONLY search scope requested"):
+        with pytest.raises(
+            ValueError,
+            match="Custom index not configured but CUSTOM_ONLY search scope requested",
+        ):
             DCClient(
                 dc=mocked_datacommons_client,
                 search_scope=SearchScope.CUSTOM_ONLY,
-                custom_index=""
+                custom_index="",
             )
 
 
@@ -146,8 +152,10 @@ class TestDCClientSearch:
     """Tests for the search_svs method of DCClient."""
 
     @pytest.mark.asyncio
-    @patch('datacommons_mcp.clients.requests.post')
-    async def test_search_svs_single_api_call(self, mock_post, mocked_datacommons_client):
+    @patch("datacommons_mcp.clients.requests.post")
+    async def test_search_svs_single_api_call(
+        self, mock_post, mocked_datacommons_client
+    ):
         """
         Test that search_svs makes a single API call with comma-separated indices.
         """
@@ -156,16 +164,13 @@ class TestDCClientSearch:
             dc=mocked_datacommons_client,
             search_scope=SearchScope.BASE_AND_CUSTOM,
             base_index="medium_ft",
-            custom_index="user_all_minilm_mem"
+            custom_index="user_all_minilm_mem",
         )
-        
+
         mock_response = Mock()
         mock_response.json.return_value = {
             "queryResults": {
-                "test query": {
-                    "SV": ["var1", "var2"],
-                    "CosineScore": [0.8, 0.6]
-                }
+                "test query": {"SV": ["var1", "var2"], "CosineScore": [0.8, 0.6]}
             }
         }
         mock_response.raise_for_status.return_value = None
@@ -180,26 +185,21 @@ class TestDCClientSearch:
         assert "idx=user_all_minilm_mem,medium_ft" in call_args[0][0]
         assert result["test query"] == [
             {"SV": "var1", "CosineScore": 0.8},
-            {"SV": "var2", "CosineScore": 0.6}
+            {"SV": "var2", "CosineScore": 0.6},
         ]
 
     @pytest.mark.asyncio
-    @patch('datacommons_mcp.clients.requests.post')
+    @patch("datacommons_mcp.clients.requests.post")
     async def test_search_svs_skip_topics(self, mock_post, mocked_datacommons_client):
         """
         Test that search_svs respects the skip_topics parameter.
         """
         # Arrange: Create client and mock response
         client_under_test = DCClient(dc=mocked_datacommons_client)
-        
+
         mock_response = Mock()
         mock_response.json.return_value = {
-            "queryResults": {
-                "test query": {
-                    "SV": ["var1"],
-                    "CosineScore": [0.8]
-                }
-            }
+            "queryResults": {"test query": {"SV": ["var1"], "CosineScore": [0.8]}}
         }
         mock_response.raise_for_status.return_value = None
         mock_post.return_value = mock_response
@@ -212,20 +212,22 @@ class TestDCClientSearch:
         assert "skip_topics=true" in call_args[0][0]
 
     @pytest.mark.asyncio
-    @patch('datacommons_mcp.clients.requests.post')
-    async def test_search_svs_max_results_limit(self, mock_post, mocked_datacommons_client):
+    @patch("datacommons_mcp.clients.requests.post")
+    async def test_search_svs_max_results_limit(
+        self, mock_post, mocked_datacommons_client
+    ):
         """
         Test that search_svs respects the max_results parameter.
         """
         # Arrange: Create client and mock response with more results than limit
         client_under_test = DCClient(dc=mocked_datacommons_client)
-        
+
         mock_response = Mock()
         mock_response.json.return_value = {
             "queryResults": {
                 "test query": {
                     "SV": ["var1", "var2", "var3", "var4", "var5"],
-                    "CosineScore": [0.9, 0.8, 0.7, 0.6, 0.5]
+                    "CosineScore": [0.9, 0.8, 0.7, 0.6, 0.5],
                 }
             }
         }
@@ -240,7 +242,7 @@ class TestDCClientSearch:
         assert result["test query"] == [
             {"SV": "var1", "CosineScore": 0.9},
             {"SV": "var2", "CosineScore": 0.8},
-            {"SV": "var3", "CosineScore": 0.7}
+            {"SV": "var3", "CosineScore": 0.7},
         ]
 
 
@@ -281,20 +283,19 @@ class TestDCClientObservations:
                     }
                 }
             },
-            "facets": {
-                "source1": {"importName": "test_source"}
-            },
+            "facets": {"source1": {"importName": "test_source"}},
         }
         mock_api_response = ObservationApiResponse.model_validate(api_response_data)
         mocked_datacommons_client.observation.fetch.return_value = mock_api_response
 
         # Mock fetch_entity_names to return place names
-        client_under_test.fetch_entity_names = Mock(return_value={"place1": "Test Place"})
+        client_under_test.fetch_entity_names = Mock(
+            return_value={"place1": "Test Place"}
+        )
 
         # Act: Call the method on our wrapper client
         result = await client_under_test.fetch_obs(request)
 
-        
         expected_response = ObservationToolResponse(
             place_data={
                 "place1": PlaceData(
@@ -307,24 +308,21 @@ class TestDCClientObservations:
                                 source_id="source1",
                                 earliest_date="2023-01-01",
                                 latest_date="2023-01-01",
-                                total_observations=1
+                                total_observations=1,
                             ),
                             observations=[{"date": "2023-01-01", "value": 100}],
-                            alternative_sources=[]
+                            alternative_sources=[],
                         )
-                    }
+                    },
                 )
             },
             source_info={
-                "source1": Source(
-                    importName="test_source",
-                    source_id="source1"
-                )
-            }
+                "source1": Source(importName="test_source", source_id="source1")
+            },
         )
-        
+
         assert result == expected_response
-        
+
         # Verify that the API was called correctly
         mocked_datacommons_client.observation.fetch.assert_called_once_with(
             variable_dcids="var1",
@@ -332,7 +330,7 @@ class TestDCClientObservations:
             date=ObservationPeriod.LATEST,
             filter_facet_ids=None,
         )
-        
+
         # Verify that place metadata was added
         client_under_test.fetch_entity_names.assert_called_once_with(["place1"])
 
@@ -380,27 +378,26 @@ class TestDCClientObservations:
                                     ],
                                 }
                             ]
-                        }
+                        },
                     }
                 }
             },
-            "facets": {
-                "source1": {"importName": "test_source"}
-            },
+            "facets": {"source1": {"importName": "test_source"}},
         }
         mock_api_response = ObservationApiResponse.model_validate(api_response_data)
         mocked_datacommons_client.observation.fetch_observations_by_entity_type.return_value = mock_api_response
 
         # Mock fetch_entity_names to return place names
-        client_under_test.fetch_entity_names = Mock(return_value={
-            "child_place1": "Child Place 1",
-            "child_place2": "Child Place 2"
-        })
+        client_under_test.fetch_entity_names = Mock(
+            return_value={
+                "child_place1": "Child Place 1",
+                "child_place2": "Child Place 2",
+            }
+        )
 
         # Act: Call the method on our wrapper client
         result = await client_under_test.fetch_obs(request)
 
-        
         expected_response = ObservationToolResponse(
             place_data={
                 "child_place1": PlaceData(
@@ -413,12 +410,12 @@ class TestDCClientObservations:
                                 source_id="source1",
                                 earliest_date="2023-01-01",
                                 latest_date="2023-01-01",
-                                total_observations=1
+                                total_observations=1,
                             ),
                             observations=[{"date": "2023-01-01", "value": 50}],
-                            alternative_sources=[]
+                            alternative_sources=[],
                         )
-                    }
+                    },
                 ),
                 "child_place2": PlaceData(
                     place_dcid="child_place2",
@@ -430,24 +427,21 @@ class TestDCClientObservations:
                                 source_id="source1",
                                 earliest_date="2023-01-01",
                                 latest_date="2023-01-01",
-                                total_observations=1
+                                total_observations=1,
                             ),
                             observations=[{"date": "2023-01-01", "value": 75}],
-                            alternative_sources=[]
+                            alternative_sources=[],
                         )
-                    }
-                )
+                    },
+                ),
             },
             source_info={
-                "source1": Source(
-                    importName="test_source",
-                    source_id="source1"
-                )
-            }
+                "source1": Source(importName="test_source", source_id="source1")
+            },
         )
-        
+
         assert result == expected_response
-        
+
         # Verify that the API was called correctly
         mocked_datacommons_client.observation.fetch_observations_by_entity_type.assert_called_once_with(
             variable_dcids="var1",
@@ -456,9 +450,11 @@ class TestDCClientObservations:
             date=ObservationPeriod.LATEST,
             filter_facet_ids=None,
         )
-        
+
         # Verify that place metadata was added for both child places
-        client_under_test.fetch_entity_names.assert_called_once_with(["child_place1", "child_place2"])
+        client_under_test.fetch_entity_names.assert_called_once_with(
+            ["child_place1", "child_place2"]
+        )
 
 
 class TestDCClientFetchTopicsAndVariables:
@@ -469,7 +465,7 @@ class TestDCClientFetchTopicsAndVariables:
         """Test basic functionality without place filtering."""
         # Arrange: Create client and mock search results
         client_under_test = DCClient(dc=mocked_datacommons_client)
-        
+
         # Mock search_svs to return topics and variables
         mock_search_results = {
             "test query": [
@@ -479,10 +475,10 @@ class TestDCClientFetchTopicsAndVariables:
                 {"SV": "dc/variable/Count_Household", "CosineScore": 0.6},
             ]
         }
-        
+
         # Mock the search_svs method
         client_under_test.search_svs = AsyncMock(return_value=mock_search_results)
-        
+
         # Mock topic store
         client_under_test.topic_store = Mock()
         client_under_test.topic_store.get_name.side_effect = lambda dcid: {
@@ -491,17 +487,15 @@ class TestDCClientFetchTopicsAndVariables:
             "dc/variable/Count_Person": "Count of Persons",
             "dc/variable/Count_Household": "Count of Households",
         }.get(dcid, dcid)
-        
+
         # Mock topic data
         client_under_test.topic_store.topics_by_dcid = {
             "dc/topic/Health": Mock(
-                member_topics=[],
-                variables=["dc/variable/Count_Person"]
+                member_topics=[], variables=["dc/variable/Count_Person"]
             ),
             "dc/topic/Economy": Mock(
-                member_topics=[],
-                variables=["dc/variable/Count_Household"]
-            )
+                member_topics=[], variables=["dc/variable/Count_Household"]
+            ),
         }
 
         # Act: Call the method
@@ -511,30 +505,32 @@ class TestDCClientFetchTopicsAndVariables:
         assert "topics" in result
         assert "variables" in result
         assert "lookups" in result
-        
+
         # Verify topics
         assert len(result["topics"]) == 2
         topic_dcids = [topic["dcid"] for topic in result["topics"]]
         assert "dc/topic/Health" in topic_dcids
         assert "dc/topic/Economy" in topic_dcids
-        
+
         # Verify variables
         assert len(result["variables"]) == 2
         variable_dcids = [var["dcid"] for var in result["variables"]]
         assert "dc/variable/Count_Person" in variable_dcids
         assert "dc/variable/Count_Household" in variable_dcids
-        
+
         # Verify lookups
         assert len(result["lookups"]) == 4
         assert result["lookups"]["dc/topic/Health"] == "Health"
         assert result["lookups"]["dc/variable/Count_Person"] == "Count of Persons"
 
     @pytest.mark.asyncio
-    async def test_fetch_topics_and_variables_with_places(self, mocked_datacommons_client):
+    async def test_fetch_topics_and_variables_with_places(
+        self, mocked_datacommons_client
+    ):
         """Test functionality with place filtering."""
         # Arrange: Create client and mock search results
         client_under_test = DCClient(dc=mocked_datacommons_client)
-        
+
         # Mock search_svs to return topics and variables
         mock_search_results = {
             "test query": [
@@ -542,25 +538,25 @@ class TestDCClientFetchTopicsAndVariables:
                 {"SV": "dc/variable/Count_Person", "CosineScore": 0.7},
             ]
         }
-        
+
         # Mock the search_svs method
         client_under_test.search_svs = AsyncMock(return_value=mock_search_results)
-        
+
         # Mock topic store
         client_under_test.topic_store = Mock()
         client_under_test.topic_store.get_name.side_effect = lambda dcid: {
             "dc/topic/Health": "Health",
             "dc/variable/Count_Person": "Count of Persons",
         }.get(dcid, dcid)
-        
+
         # Mock topic data
         client_under_test.topic_store.topics_by_dcid = {
             "dc/topic/Health": Mock(
                 member_topics=[],
-                variables=["dc/variable/Count_Person", "dc/variable/Count_Household"]
+                variables=["dc/variable/Count_Person", "dc/variable/Count_Household"],
             )
         }
-        
+
         # Mock variable cache to simulate data existence
         client_under_test.variable_cache = Mock()
         client_under_test.variable_cache.get.side_effect = lambda place_dcid: {
@@ -590,7 +586,11 @@ class TestDCClientFetchTopicsAndVariables:
         }.get(place_dcid, set())
 
         # Act: Filter variables
-        variables = ["dc/variable/Count_Person", "dc/variable/Count_Household", "dc/variable/Count_Business"]
+        variables = [
+            "dc/variable/Count_Person",
+            "dc/variable/Count_Household",
+            "dc/variable/Count_Business",
+        ]
         result = client_under_test._filter_variables_by_existence(
             variables, ["geoId/06", "geoId/36"]
         )
@@ -601,9 +601,11 @@ class TestDCClientFetchTopicsAndVariables:
         assert "dc/variable/Count_Person" in var_dcids
         assert "dc/variable/Count_Household" in var_dcids
         assert "dc/variable/Count_Business" not in var_dcids
-        
+
         # Verify places_with_data
-        count_person = next(var for var in result if var["dcid"] == "dc/variable/Count_Person")
+        count_person = next(
+            var for var in result if var["dcid"] == "dc/variable/Count_Person"
+        )
         assert count_person["places_with_data"] == ["geoId/06", "geoId/36"]
 
     def test_filter_topics_by_existence(self, mocked_datacommons_client):
@@ -613,11 +615,10 @@ class TestDCClientFetchTopicsAndVariables:
         client_under_test.topic_store = Mock()
         client_under_test.topic_store.topics_by_dcid = {
             "dc/topic/Health": Mock(
-                member_topics=[],
-                variables=["dc/variable/Count_Person"]
+                member_topics=[], variables=["dc/variable/Count_Person"]
             )
         }
-        
+
         # Mock variable cache
         client_under_test.variable_cache = Mock()
         client_under_test.variable_cache.get.side_effect = lambda place_dcid: {
@@ -644,10 +645,10 @@ class TestDCClientFetchTopicsAndVariables:
         client_under_test.topic_store.topics_by_dcid = {
             "dc/topic/Health": Mock(
                 member_topics=["dc/topic/HealthCare"],
-                variables=["dc/variable/Count_Person", "dc/variable/Count_Household"]
+                variables=["dc/variable/Count_Person", "dc/variable/Count_Household"],
             )
         }
-        
+
         # Mock variable cache
         client_under_test.variable_cache = Mock()
         client_under_test.variable_cache.get.side_effect = lambda place_dcid: {
@@ -668,24 +669,29 @@ class TestDCClientFetchTopicsAndVariables:
         assert health_topic["member_topics"] == []
 
     @pytest.mark.asyncio
-    async def test_search_entities_filters_invalid_topics(self, mocked_datacommons_client):
+    async def test_search_entities_filters_invalid_topics(
+        self, mocked_datacommons_client
+    ):
         """Test that _search_entities filters out topics that don't exist in the topic store."""
         # Arrange: Create client and mock search results
         client_under_test = DCClient(dc=mocked_datacommons_client)
-        
+
         # Mock search_svs to return topics (some valid, some invalid) and variables
         mock_search_results = {
             "test query": [
                 {"SV": "dc/topic/Health", "CosineScore": 0.9},  # Valid topic
-                {"SV": "dc/topic/InvalidTopic", "CosineScore": 0.8},  # Invalid topic (not in store)
+                {
+                    "SV": "dc/topic/InvalidTopic",
+                    "CosineScore": 0.8,
+                },  # Invalid topic (not in store)
                 {"SV": "dc/topic/Economy", "CosineScore": 0.7},  # Valid topic
                 {"SV": "dc/variable/Count_Person", "CosineScore": 0.6},  # Variable
             ]
         }
-        
+
         # Mock the search_svs method
         client_under_test.search_svs = AsyncMock(return_value=mock_search_results)
-        
+
         # Mock topic store to only contain some topics
         client_under_test.topic_store = Mock()
         client_under_test.topic_store.topics_by_dcid = {
@@ -700,13 +706,15 @@ class TestDCClientFetchTopicsAndVariables:
         # Assert: Verify that only valid topics are returned
         assert "topics" in result
         assert "variables" in result
-        
+
         # Verify topics - should only include topics that exist in the topic store
         assert len(result["topics"]) == 2
         assert "dc/topic/Health" in result["topics"]
         assert "dc/topic/Economy" in result["topics"]
-        assert "dc/topic/InvalidTopic" not in result["topics"]  # Invalid topic should be filtered out
-        
+        assert (
+            "dc/topic/InvalidTopic" not in result["topics"]
+        )  # Invalid topic should be filtered out
+
         # Verify variables - should include all variables
         assert len(result["variables"]) == 1
         assert "dc/variable/Count_Person" in result["variables"]
@@ -716,7 +724,7 @@ class TestDCClientFetchTopicsAndVariables:
         """Test that _search_entities handles case when topic store is None."""
         # Arrange: Create client and mock search results
         client_under_test = DCClient(dc=mocked_datacommons_client)
-        
+
         # Mock search_svs to return topics and variables
         mock_search_results = {
             "test query": [
@@ -724,10 +732,10 @@ class TestDCClientFetchTopicsAndVariables:
                 {"SV": "dc/variable/Count_Person", "CosineScore": 0.6},
             ]
         }
-        
+
         # Mock the search_svs method
         client_under_test.search_svs = AsyncMock(return_value=mock_search_results)
-        
+
         # Set topic store to None
         client_under_test.topic_store = None
 
@@ -737,19 +745,21 @@ class TestDCClientFetchTopicsAndVariables:
         # Assert: Verify that no topics are returned when topic store is None
         assert "topics" in result
         assert "variables" in result
-        
+
         # Verify topics - should be empty when topic store is None
         assert len(result["topics"]) == 0
-        
+
         # Verify variables - should include all variables
         assert len(result["variables"]) == 1
         assert "dc/variable/Count_Person" in result["variables"]
 
     @pytest.mark.asyncio
-    async def test_search_entities_with_per_search_limit(self, mocked_datacommons_client):
+    async def test_search_entities_with_per_search_limit(
+        self, mocked_datacommons_client
+    ):
         """Test _search_entities with per_search_limit parameter."""
         client_under_test = DCClient(dc=mocked_datacommons_client)
-        
+
         # Mock search_svs to return results
         mock_search_results = {
             "test query": [
@@ -822,9 +832,7 @@ class TestDCClientIntegrateObservationResponse:
     def test_integrate_observation_initial_data(self, mock_api_response):
         """Test that _integrate_observation_response correctly processes initial data."""
         response = ObservationToolResponse()
-        DCClient._integrate_observation_response(
-            response, mock_api_response
-        )
+        DCClient._integrate_observation_response(response, mock_api_response)
 
         assert "place1" in response.place_data
         place_data = response.place_data["place1"]
@@ -850,9 +858,7 @@ class TestDCClientIntegrateObservationResponse:
         )
         response.place_data["place1"] = Mock(variable_series={"var1": initial_series})
 
-        DCClient._integrate_observation_response(
-            response, mock_api_response
-        )
+        DCClient._integrate_observation_response(response, mock_api_response)
 
         # Check that the new sources were appended
         final_series = response.place_data["place1"].variable_series["var1"]
@@ -879,13 +885,12 @@ class TestCreateDCClient:
 
     @patch("datacommons_mcp.clients.DataCommonsClient")
     @patch("datacommons_mcp.clients.read_topic_cache")
-    def test_create_dc_client_base_dc(self, mock_read_cache: Mock, mock_dc_client: Mock):
+    def test_create_dc_client_base_dc(
+        self, mock_read_cache: Mock, mock_dc_client: Mock
+    ):
         """Test base DC creation with defaults."""
         # Arrange
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_api_key',
-            'DC_TYPE': 'base'
-        }):
+        with patch.dict(os.environ, {"DC_API_KEY": "test_api_key", "DC_TYPE": "base"}):
             settings = BaseDCSettings()
             mock_dc_instance = Mock()
             mock_dc_client.return_value = mock_dc_instance
@@ -904,14 +909,19 @@ class TestCreateDCClient:
 
     @patch("datacommons_mcp.clients.DataCommonsClient")
     @patch("datacommons_mcp.clients.create_topic_store")
-    def test_create_dc_client_custom_dc(self, mock_create_store: Mock, mock_dc_client: Mock):
+    def test_create_dc_client_custom_dc(
+        self, mock_create_store: Mock, mock_dc_client: Mock
+    ):
         """Test custom DC creation with defaults."""
         # Arrange
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_api_key',
-            'DC_TYPE': 'custom',
-            'CUSTOM_DC_URL': 'https://staging-datacommons-web-service-650536812276.northamerica-northeast1.run.app'
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "DC_API_KEY": "test_api_key",
+                "DC_TYPE": "custom",
+                "CUSTOM_DC_URL": "https://staging-datacommons-web-service-650536812276.northamerica-northeast1.run.app",
+            },
+        ):
             settings = CustomDCSettings()
             mock_dc_instance = Mock()
             mock_dc_client.return_value = mock_dc_instance
@@ -927,7 +937,10 @@ class TestCreateDCClient:
             assert result.search_scope == SearchScope.BASE_AND_CUSTOM
             assert result.base_index == "medium_ft"
             assert result.custom_index == "user_all_minilm_mem"
-            assert result.sv_search_base_url == "https://staging-datacommons-web-service-650536812276.northamerica-northeast1.run.app"
+            assert (
+                result.sv_search_base_url
+                == "https://staging-datacommons-web-service-650536812276.northamerica-northeast1.run.app"
+            )
             # Should have called DataCommonsClient with computed api_base_url
             expected_api_url = "https://staging-datacommons-web-service-650536812276.northamerica-northeast1.run.app/core/api/v2/"
             mock_dc_client.assert_called_with(url=expected_api_url)
@@ -936,17 +949,20 @@ class TestCreateDCClient:
     def test_create_dc_client_url_computation(self, mock_dc_client):
         """Test URL computation for custom DC."""
         # Arrange
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_api_key',
-            'DC_TYPE': 'custom',
-            'CUSTOM_DC_URL': 'https://example.com'  # No trailing slash
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "DC_API_KEY": "test_api_key",
+                "DC_TYPE": "custom",
+                "CUSTOM_DC_URL": "https://example.com",  # No trailing slash
+            },
+        ):
             settings = CustomDCSettings()
             mock_dc_instance = Mock()
             mock_dc_client.return_value = mock_dc_instance
 
             # Act
-            result = create_dc_client(settings)
+            _ = create_dc_client(settings)
 
             # Assert
             # Should compute api_base_url by adding /core/api/v2/

--- a/packages/datacommons-mcp/tests/test_services.py
+++ b/packages/datacommons-mcp/tests/test_services.py
@@ -229,7 +229,6 @@ class TestSearchIndicators:
         # The second call should be with the place name appended to query
         assert calls[1].kwargs["query"] == "trade exports France"
         assert calls[1].kwargs["place_dcids"] == []
-        assert calls[1].kwargs["place_dcids"] == []
 
     @pytest.mark.asyncio
     async def test_search_indicators_browse_mode_merge_results(self):

--- a/packages/datacommons-mcp/tests/test_services.py
+++ b/packages/datacommons-mcp/tests/test_services.py
@@ -15,8 +15,9 @@
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from datacommons_mcp.clients import DCClient
 from datacommons_mcp.data_models.observations import ObservationPeriod
-from datacommons_mcp.exceptions import NoDataFoundError
+from datacommons_mcp.exceptions import DataLookupError
 from datacommons_mcp.services import (
     _build_observation_request,
     get_observations,
@@ -28,7 +29,7 @@ from datacommons_mcp.services import (
 class TestBuildObservationRequest:
     @pytest.fixture
     def mock_client(self):
-        client = Mock()
+        client = Mock(spec=DCClient)
         client.search_places = AsyncMock()
         return client
 
@@ -82,7 +83,7 @@ class TestBuildObservationRequest:
 
     async def test_resolution_failure(self, mock_client):
         mock_client.search_places.return_value = {}  # No place found
-        with pytest.raises(NoDataFoundError, match="NoDataFoundError: No place found"):
+        with pytest.raises(DataLookupError, match="DataLookupError: No place found"):
             await _build_observation_request(
                 mock_client, variable_dcid="var1", place_name="invalid"
             )

--- a/packages/datacommons-mcp/tests/test_services.py
+++ b/packages/datacommons-mcp/tests/test_services.py
@@ -154,9 +154,6 @@ class TestGetObservations:
         assert call_args.observation_period == ObservationPeriod.LATEST
 
 
-
-
-
 @pytest.mark.asyncio
 class TestSearchIndicators:
     """Tests for the search_indicators service function."""
@@ -165,19 +162,19 @@ class TestSearchIndicators:
     async def test_search_indicators_browse_mode_basic(self):
         """Test basic search in browse mode without place filtering."""
         mock_client = Mock()
-        mock_client.fetch_topics_and_variables = AsyncMock(return_value={
-            "topics": [{"dcid": "topic/health"}],
-            "variables": [{"dcid": "Count_Person"}],
-            "lookups": {"topic/health": "Health", "Count_Person": "Population"}
-        })
-        mock_client.fetch_entity_names = Mock(return_value={
-            "topic/health": "Health", "Count_Person": "Population"
-        })
+        mock_client.fetch_topics_and_variables = AsyncMock(
+            return_value={
+                "topics": [{"dcid": "topic/health"}],
+                "variables": [{"dcid": "Count_Person"}],
+                "lookups": {"topic/health": "Health", "Count_Person": "Population"},
+            }
+        )
+        mock_client.fetch_entity_names = Mock(
+            return_value={"topic/health": "Health", "Count_Person": "Population"}
+        )
 
         result = await search_indicators(
-            client=mock_client,
-            query="health",
-            mode="browse"
+            client=mock_client, query="health", mode="browse"
         )
 
         assert result.topics is not None
@@ -191,20 +188,29 @@ class TestSearchIndicators:
         """Test search in browse mode with place filtering."""
         mock_client = Mock()
         mock_client.search_places = AsyncMock(return_value={"France": "country/FRA"})
-        mock_client.fetch_topics_and_variables = AsyncMock(return_value={
-            "topics": [{"dcid": "topic/trade"}],
-            "variables": [{"dcid": "TradeExports_FRA"}],
-            "lookups": {"topic/trade": "Trade", "TradeExports_FRA": "Exports to France"}
-        })
-        mock_client.fetch_entity_names = Mock(return_value={
-            "topic/trade": "Trade", "TradeExports_FRA": "Exports to France", "country/FRA": "France"
-        })
+        mock_client.fetch_topics_and_variables = AsyncMock(
+            return_value={
+                "topics": [{"dcid": "topic/trade"}],
+                "variables": [{"dcid": "TradeExports_FRA"}],
+                "lookups": {
+                    "topic/trade": "Trade",
+                    "TradeExports_FRA": "Exports to France",
+                },
+            }
+        )
+        mock_client.fetch_entity_names = Mock(
+            return_value={
+                "topic/trade": "Trade",
+                "TradeExports_FRA": "Exports to France",
+                "country/FRA": "France",
+            }
+        )
 
         result = await search_indicators(
             client=mock_client,
             query="trade exports",
             mode="browse",
-            place1_name="France"
+            place1_name="France",
         )
 
         assert result.topics is not None
@@ -263,15 +269,14 @@ class TestSearchIndicators:
         )
 
         result = await search_indicators(
-            client=mock_client,
-            query="trade",
-            mode="browse",
-            place1_name="France"
+            client=mock_client, query="trade", mode="browse", place1_name="France"
         )
 
         # Should have deduplicated topics and variables
         assert len(result.topics) == 1  # Deduplicated
-        assert len(result.variables) == 2  # Both unique variables included (duplicate removed)
+        assert (
+            len(result.variables) == 2
+        )  # Both unique variables included (duplicate removed)
         assert "TradeExports_FRA" in [v.dcid for v in result.variables]
         assert "TradeImports_FRA" in [v.dcid for v in result.variables]
 
@@ -279,20 +284,19 @@ class TestSearchIndicators:
     async def test_search_indicators_browse_mode_with_custom_per_search_limit(self):
         """Test search in browse mode with custom per_search_limit parameter."""
         mock_client = Mock()
-        mock_client.fetch_topics_and_variables = AsyncMock(return_value={
-            "topics": [{"dcid": "topic/health"}],
-            "variables": [{"dcid": "Count_Person"}],
-            "lookups": {"topic/health": "Health", "Count_Person": "Population"}
-        })
-        mock_client.fetch_entity_names = Mock(return_value={
-            "topic/health": "Health", "Count_Person": "Population"
-        })
+        mock_client.fetch_topics_and_variables = AsyncMock(
+            return_value={
+                "topics": [{"dcid": "topic/health"}],
+                "variables": [{"dcid": "Count_Person"}],
+                "lookups": {"topic/health": "Health", "Count_Person": "Population"},
+            }
+        )
+        mock_client.fetch_entity_names = Mock(
+            return_value={"topic/health": "Health", "Count_Person": "Population"}
+        )
 
         result = await search_indicators(
-            client=mock_client,
-            query="health",
-            mode="browse",
-            per_search_limit=5
+            client=mock_client, query="health", mode="browse", per_search_limit=5
         )
 
         assert result.topics is not None
@@ -310,20 +314,18 @@ class TestSearchIndicators:
         mock_client = Mock()
 
         # Test invalid per_search_limit values
-        with pytest.raises(ValueError, match="per_search_limit must be between 1 and 100"):
+        with pytest.raises(
+            ValueError, match="per_search_limit must be between 1 and 100"
+        ):
             await search_indicators(
-                client=mock_client,
-                query="health",
-                mode="browse",
-                per_search_limit=0
+                client=mock_client, query="health", mode="browse", per_search_limit=0
             )
 
-        with pytest.raises(ValueError, match="per_search_limit must be between 1 and 100"):
+        with pytest.raises(
+            ValueError, match="per_search_limit must be between 1 and 100"
+        ):
             await search_indicators(
-                client=mock_client,
-                query="health",
-                mode="browse",
-                per_search_limit=101
+                client=mock_client, query="health", mode="browse", per_search_limit=101
             )
 
         # Test valid per_search_limit values
@@ -332,8 +334,12 @@ class TestSearchIndicators:
         )
 
         # Should not raise for valid values
-        await search_indicators(client=mock_client, query="health", mode="browse", per_search_limit=1)
-        await search_indicators(client=mock_client, query="health", mode="browse", per_search_limit=100)
+        await search_indicators(
+            client=mock_client, query="health", mode="browse", per_search_limit=1
+        )
+        await search_indicators(
+            client=mock_client, query="health", mode="browse", per_search_limit=100
+        )
 
     @pytest.mark.asyncio
     async def test_search_indicators_browse_mode_default_per_search_limit(self):
@@ -354,19 +360,18 @@ class TestSearchIndicators:
     async def test_search_indicators_browse_mode_default_mode(self):
         """Test that browse mode is the default when mode is not specified."""
         mock_client = Mock()
-        mock_client.fetch_topics_and_variables = AsyncMock(return_value={
-            "topics": [{"dcid": "topic/health"}],
-            "variables": [{"dcid": "Count_Person"}],
-            "lookups": {"topic/health": "Health", "Count_Person": "Population"}
-        })
-        mock_client.fetch_entity_names = Mock(return_value={
-            "topic/health": "Health", "Count_Person": "Population"
-        })
-
-        result = await search_indicators(
-            client=mock_client,
-            query="health"
+        mock_client.fetch_topics_and_variables = AsyncMock(
+            return_value={
+                "topics": [{"dcid": "topic/health"}],
+                "variables": [{"dcid": "Count_Person"}],
+                "lookups": {"topic/health": "Health", "Count_Person": "Population"},
+            }
         )
+        mock_client.fetch_entity_names = Mock(
+            return_value={"topic/health": "Health", "Count_Person": "Population"}
+        )
+
+        result = await search_indicators(client=mock_client, query="health")
 
         assert result.topics is not None
         assert result.variables is not None
@@ -380,22 +385,24 @@ class TestSearchIndicators:
         mock_client = Mock()
 
         # Test invalid mode values
-        with pytest.raises(ValueError, match="mode must be either 'browse' or 'lookup'"):
+        with pytest.raises(
+            ValueError, match="mode must be either 'browse' or 'lookup'"
+        ):
             await search_indicators(
-                client=mock_client,
-                query="health",
-                mode="invalid_mode"
+                client=mock_client, query="health", mode="invalid_mode"
             )
 
         # Test valid mode values
-        mock_client.fetch_topics_and_variables = AsyncMock(return_value={
-            "topics": [], "variables": [], "lookups": {}
-        })
+        mock_client.fetch_topics_and_variables = AsyncMock(
+            return_value={"topics": [], "variables": [], "lookups": {}}
+        )
 
         # Should not raise for valid values
         await search_indicators(client=mock_client, query="health", mode="browse")
         await search_indicators(client=mock_client, query="health", mode="lookup")
-        await search_indicators(client=mock_client, query="health", mode=None)  # None should default to browse
+        await search_indicators(
+            client=mock_client, query="health", mode=None
+        )  # None should default to browse
 
     # Phase 2: Lookup Mode Tests
     @pytest.mark.asyncio
@@ -403,18 +410,19 @@ class TestSearchIndicators:
         """Test basic search in lookup mode with a single place."""
         mock_client = Mock()
         mock_client.search_places = AsyncMock(return_value={"USA": "country/USA"})
-        mock_client.fetch_topic_variables = AsyncMock(return_value={
-            "topic_variable_ids": ["Count_Person", "Count_Household"]
-        })
-        mock_client.fetch_entity_names = Mock(return_value={
-            "Count_Person": "Population", "Count_Household": "Households", "country/USA": "USA"
-        })
+        mock_client.fetch_topic_variables = AsyncMock(
+            return_value={"topic_variable_ids": ["Count_Person", "Count_Household"]}
+        )
+        mock_client.fetch_entity_names = Mock(
+            return_value={
+                "Count_Person": "Population",
+                "Count_Household": "Households",
+                "country/USA": "USA",
+            }
+        )
 
         result = await search_indicators(
-            client=mock_client,
-            query="health",
-            mode="lookup",
-            place1_name="USA"
+            client=mock_client, query="health", mode="lookup", place1_name="USA"
         )
 
         assert result.topics is None  # No topics in lookup mode
@@ -431,20 +439,24 @@ class TestSearchIndicators:
         """Test search in lookup mode with place filtering."""
         mock_client = Mock()
         mock_client.search_places = AsyncMock(return_value={"France": "country/FRA"})
-        mock_client.fetch_topic_variables = AsyncMock(return_value={
-            "topic_variable_ids": ["TradeExports_FRA", "TradeImports_FRA"]
-        })
-        mock_client.fetch_entity_names = Mock(return_value={
-            "TradeExports_FRA": "Exports to France", 
-            "TradeImports_FRA": "Imports from France",
-            "country/FRA": "France"
-        })
+        mock_client.fetch_topic_variables = AsyncMock(
+            return_value={
+                "topic_variable_ids": ["TradeExports_FRA", "TradeImports_FRA"]
+            }
+        )
+        mock_client.fetch_entity_names = Mock(
+            return_value={
+                "TradeExports_FRA": "Exports to France",
+                "TradeImports_FRA": "Imports from France",
+                "country/FRA": "France",
+            }
+        )
 
         result = await search_indicators(
             client=mock_client,
             query="trade exports",
             mode="lookup",
-            place1_name="France"
+            place1_name="France",
         )
 
         assert result.topics is None  # No topics in lookup mode
@@ -464,29 +476,39 @@ class TestSearchIndicators:
     async def test_search_indicators_lookup_mode_merge_results(self):
         """Test that results from multiple searches are properly merged in lookup mode."""
         mock_client = Mock()
-        mock_client.search_places = AsyncMock(return_value={"France": "country/FRA", "Germany": "country/DEU"})
-        mock_client.fetch_topic_variables = AsyncMock(side_effect=[
-            {"topic_variable_ids": ["TradeExports_FRA"]},  # France results
-            {"topic_variable_ids": ["TradeExports_DEU", "TradeExports_FRA"]}  # Germany results (with duplicate)
-        ])
-        mock_client.fetch_entity_names = Mock(return_value={
-            "TradeExports_FRA": "Exports to France",
-            "TradeExports_DEU": "Exports to Germany",
-            "country/FRA": "France",
-            "country/DEU": "Germany"
-        })
+        mock_client.search_places = AsyncMock(
+            return_value={"France": "country/FRA", "Germany": "country/DEU"}
+        )
+        mock_client.fetch_topic_variables = AsyncMock(
+            side_effect=[
+                {"topic_variable_ids": ["TradeExports_FRA"]},  # France results
+                {
+                    "topic_variable_ids": ["TradeExports_DEU", "TradeExports_FRA"]
+                },  # Germany results (with duplicate)
+            ]
+        )
+        mock_client.fetch_entity_names = Mock(
+            return_value={
+                "TradeExports_FRA": "Exports to France",
+                "TradeExports_DEU": "Exports to Germany",
+                "country/FRA": "France",
+                "country/DEU": "Germany",
+            }
+        )
 
         result = await search_indicators(
             client=mock_client,
             query="trade",
             mode="lookup",
             place1_name="France",
-            place2_name="Germany"
+            place2_name="Germany",
         )
 
         # Should have deduplicated variables
         assert result.topics is None  # No topics in lookup mode
-        assert len(result.variables) == 2  # Both unique variables included (duplicate removed)
+        assert (
+            len(result.variables) == 2
+        )  # Both unique variables included (duplicate removed)
         assert any(v.dcid == "TradeExports_FRA" for v in result.variables)
         assert any(v.dcid == "TradeExports_DEU" for v in result.variables)
 
@@ -495,22 +517,30 @@ class TestSearchIndicators:
         """Test search in lookup mode with custom per_search_limit parameter."""
         mock_client = Mock()
         mock_client.search_places = AsyncMock(return_value={"USA": "country/USA"})
-        mock_client.fetch_topic_variables = AsyncMock(return_value={
-            "topic_variable_ids": ["Count_Person", "Count_Household", "Count_Business"]
-        })
-        mock_client.fetch_entity_names = Mock(return_value={
-            "Count_Person": "Population", 
-            "Count_Household": "Households",
-            "Count_Business": "Businesses",
-            "country/USA": "USA"
-        })
+        mock_client.fetch_topic_variables = AsyncMock(
+            return_value={
+                "topic_variable_ids": [
+                    "Count_Person",
+                    "Count_Household",
+                    "Count_Business",
+                ]
+            }
+        )
+        mock_client.fetch_entity_names = Mock(
+            return_value={
+                "Count_Person": "Population",
+                "Count_Household": "Households",
+                "Count_Business": "Businesses",
+                "country/USA": "USA",
+            }
+        )
 
         result = await search_indicators(
             client=mock_client,
             query="health",
             mode="lookup",
             place1_name="USA",
-            per_search_limit=2
+            per_search_limit=2,
         )
 
         assert result.topics is None  # No topics in lookup mode
@@ -526,48 +556,56 @@ class TestSearchIndicators:
         mock_client = Mock()
 
         # Test invalid per_search_limit values
-        with pytest.raises(ValueError, match="per_search_limit must be between 1 and 100"):
+        with pytest.raises(
+            ValueError, match="per_search_limit must be between 1 and 100"
+        ):
             await search_indicators(
-                client=mock_client,
-                query="health",
-                mode="lookup",
-                per_search_limit=0
+                client=mock_client, query="health", mode="lookup", per_search_limit=0
             )
 
-        with pytest.raises(ValueError, match="per_search_limit must be between 1 and 100"):
+        with pytest.raises(
+            ValueError, match="per_search_limit must be between 1 and 100"
+        ):
             await search_indicators(
-                client=mock_client,
-                query="health",
-                mode="lookup",
-                per_search_limit=101
+                client=mock_client, query="health", mode="lookup", per_search_limit=101
             )
 
         # Test valid per_search_limit values with place (so lookup mode is actually used)
         mock_client.search_places = AsyncMock(return_value={"USA": "country/USA"})
-        mock_client.fetch_topic_variables = AsyncMock(return_value={
-            "topic_variable_ids": []
-        })
-        mock_client.fetch_entity_names = Mock(return_value={
-            "country/USA": "USA"
-        })
+        mock_client.fetch_topic_variables = AsyncMock(
+            return_value={"topic_variable_ids": []}
+        )
+        mock_client.fetch_entity_names = Mock(return_value={"country/USA": "USA"})
 
         # Should not raise for valid values
-        await search_indicators(client=mock_client, query="health", mode="lookup", place1_name="USA", per_search_limit=1)
-        await search_indicators(client=mock_client, query="health", mode="lookup", place1_name="USA", per_search_limit=100)
+        await search_indicators(
+            client=mock_client,
+            query="health",
+            mode="lookup",
+            place1_name="USA",
+            per_search_limit=1,
+        )
+        await search_indicators(
+            client=mock_client,
+            query="health",
+            mode="lookup",
+            place1_name="USA",
+            per_search_limit=100,
+        )
 
     @pytest.mark.asyncio
     async def test_search_indicators_lookup_mode_default_per_search_limit(self):
         """Test that default per_search_limit=10 is used when not specified in lookup mode."""
         mock_client = Mock()
         mock_client.search_places = AsyncMock(return_value={"USA": "country/USA"})
-        mock_client.fetch_topic_variables = AsyncMock(return_value={
-            "topic_variable_ids": []
-        })
-        mock_client.fetch_entity_names = Mock(return_value={
-            "country/USA": "USA"
-        })
+        mock_client.fetch_topic_variables = AsyncMock(
+            return_value={"topic_variable_ids": []}
+        )
+        mock_client.fetch_entity_names = Mock(return_value={"country/USA": "USA"})
 
-        await search_indicators(client=mock_client, query="health", mode="lookup", place1_name="USA")
+        await search_indicators(
+            client=mock_client, query="health", mode="lookup", place1_name="USA"
+        )
 
         # Verify default per_search_limit=10 was used (though not directly passed to fetch_topic_variables)
         # The limit is applied after fetching results
@@ -577,20 +615,22 @@ class TestSearchIndicators:
     async def test_search_indicators_automatic_fallback_to_browse_mode(self):
         """Test that lookup mode automatically falls back to browse mode when no places are provided."""
         mock_client = Mock()
-        mock_client.fetch_topics_and_variables = AsyncMock(return_value={
-            "topics": [{"dcid": "topic/health"}],
-            "variables": [{"dcid": "Count_Person"}],
-            "lookups": {"topic/health": "Health", "Count_Person": "Population"}
-        })
-        mock_client.fetch_entity_names = Mock(return_value={
-            "topic/health": "Health", "Count_Person": "Population"
-        })
+        mock_client.fetch_topics_and_variables = AsyncMock(
+            return_value={
+                "topics": [{"dcid": "topic/health"}],
+                "variables": [{"dcid": "Count_Person"}],
+                "lookups": {"topic/health": "Health", "Count_Person": "Population"},
+            }
+        )
+        mock_client.fetch_entity_names = Mock(
+            return_value={"topic/health": "Health", "Count_Person": "Population"}
+        )
 
         # Call with lookup mode but no places - should automatically fall back to browse mode
         result = await search_indicators(
             client=mock_client,
             query="health",
-            mode="lookup"  # No places provided
+            mode="lookup",  # No places provided
         )
 
         # Should return browse mode results (topics populated)

--- a/packages/datacommons-mcp/tests/test_services.py
+++ b/packages/datacommons-mcp/tests/test_services.py
@@ -17,7 +17,11 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 from datacommons_mcp.data_models.observations import ObservationPeriod
 from datacommons_mcp.exceptions import NoDataFoundError
-from datacommons_mcp.services import _build_observation_request, get_observations, search_topics_and_variables
+from datacommons_mcp.services import (
+    _build_observation_request,
+    get_observations,
+    search_topics_and_variables,
+)
 
 
 @pytest.mark.asyncio
@@ -105,15 +109,15 @@ class TestGetObservations:
             client=mock_client,
             variable_dcid="Count_Person",
             place_name="USA",
-            period="latest"
+            period="latest",
         )
 
         # Verify the result
         assert result == mock_response
-        
+
         # Verify search_places was called
         mock_client.search_places.assert_awaited_once_with(["USA"])
-        
+
         # Verify fetch_obs was called with the correct request
         mock_client.fetch_obs.assert_awaited_once()
         call_args = mock_client.fetch_obs.call_args[0][0]
@@ -132,15 +136,15 @@ class TestGetObservations:
             client=mock_client,
             variable_dcid="Count_Person",
             place_dcid="country/USA",
-            period="latest"
+            period="latest",
         )
 
         # Verify the result
         assert result == mock_response
-        
+
         # Verify search_places was NOT called (since we provided DCID)
         mock_client.search_places.assert_not_called()
-        
+
         # Verify fetch_obs was called with the correct request
         mock_client.fetch_obs.assert_awaited_once()
         call_args = mock_client.fetch_obs.call_args[0][0]
@@ -157,16 +161,15 @@ class TestSearchTopicsAndVariables:
     async def test_search_topics_and_variables_basic(self):
         """Test basic search without place filtering."""
         mock_client = Mock()
-        mock_client.fetch_topics_and_variables = AsyncMock(return_value={
-            "topics": [{"dcid": "topic/health"}],
-            "variables": [{"dcid": "Count_Person"}],
-            "lookups": {"topic/health": "Health", "Count_Person": "Population"}
-        })
-
-        result = await search_topics_and_variables(
-            client=mock_client,
-            query="health"
+        mock_client.fetch_topics_and_variables = AsyncMock(
+            return_value={
+                "topics": [{"dcid": "topic/health"}],
+                "variables": [{"dcid": "Count_Person"}],
+                "lookups": {"topic/health": "Health", "Count_Person": "Population"},
+            }
         )
+
+        result = await search_topics_and_variables(client=mock_client, query="health")
 
         assert "topics" in result
         assert "variables" in result
@@ -178,16 +181,19 @@ class TestSearchTopicsAndVariables:
         """Test search with place filtering."""
         mock_client = Mock()
         mock_client.search_places = AsyncMock(return_value={"France": "country/FRA"})
-        mock_client.fetch_topics_and_variables = AsyncMock(return_value={
-            "topics": [{"dcid": "topic/trade"}],
-            "variables": [{"dcid": "TradeExports_FRA"}],
-            "lookups": {"topic/trade": "Trade", "TradeExports_FRA": "Exports to France"}
-        })
+        mock_client.fetch_topics_and_variables = AsyncMock(
+            return_value={
+                "topics": [{"dcid": "topic/trade"}],
+                "variables": [{"dcid": "TradeExports_FRA"}],
+                "lookups": {
+                    "topic/trade": "Trade",
+                    "TradeExports_FRA": "Exports to France",
+                },
+            }
+        )
 
         result = await search_topics_and_variables(
-            client=mock_client,
-            query="trade exports",
-            place1_name="France"
+            client=mock_client, query="trade exports", place1_name="France"
         )
 
         assert "topics" in result
@@ -204,50 +210,54 @@ class TestSearchTopicsAndVariables:
         assert calls[0].kwargs["place_dcids"] == ["country/FRA"]
         # The second call should be with the place name appended to query
         assert calls[1].kwargs["query"] == "trade exports France"
-        assert calls[1].kwargs["place_dcids"] == []  
+        assert calls[1].kwargs["place_dcids"] == []
 
     @pytest.mark.asyncio
     async def test_search_topics_and_variables_merge_results(self):
         """Test that results from multiple searches are properly merged."""
         mock_client = Mock()
         mock_client.search_places = AsyncMock(return_value={"France": "country/FRA"})
-        mock_client.fetch_topics_and_variables = AsyncMock(side_effect=[
-            {
-                "topics": [{"dcid": "topic/trade"}],
-                "variables": [{"dcid": "TradeExports_FRA"}],
-                "lookups": {
-                    "topic/trade": "Trade", 
-                    "TradeExports_FRA": "Exports to France"
-                }
-            },
-            {
-                "topics": [{"dcid": "topic/trade"}],  # Duplicate topic
-                "variables": [
-                    {"dcid": "TradeImports_FRA"},  # New variable
-                    {"dcid": "TradeExports_FRA"}   # Duplicate variable
-                ],
-                "lookups": {
-                    "topic/trade": "Trade", 
-                    "TradeImports_FRA": "Imports from France", 
-                    "TradeExports_FRA": "Exports to France"
-                }
+        mock_client.fetch_topics_and_variables = AsyncMock(
+            side_effect=[
+                {
+                    "topics": [{"dcid": "topic/trade"}],
+                    "variables": [{"dcid": "TradeExports_FRA"}],
+                    "lookups": {
+                        "topic/trade": "Trade",
+                        "TradeExports_FRA": "Exports to France",
+                    },
+                },
+                {
+                    "topics": [{"dcid": "topic/trade"}],  # Duplicate topic
+                    "variables": [
+                        {"dcid": "TradeImports_FRA"},  # New variable
+                        {"dcid": "TradeExports_FRA"},  # Duplicate variable
+                    ],
+                    "lookups": {
+                        "topic/trade": "Trade",
+                        "TradeImports_FRA": "Imports from France",
+                        "TradeExports_FRA": "Exports to France",
+                    },
+                },
+            ]
+        )
+        mock_client.fetch_entity_names = Mock(
+            return_value={
+                "topic/trade": "Trade",
+                "TradeExports_FRA": "Exports to France",
+                "TradeImports_FRA": "Imports from France",
             }
-        ])
-        mock_client.fetch_entity_names = Mock(return_value={
-            "topic/trade": "Trade",
-            "TradeExports_FRA": "Exports to France",
-            "TradeImports_FRA": "Imports from France"
-        })
+        )
 
         result = await search_topics_and_variables(
-            client=mock_client,
-            query="trade",
-            place1_name="France"
+            client=mock_client, query="trade", place1_name="France"
         )
 
         # Should have deduplicated topics and variables
         assert len(result["topics"]) == 1  # Deduplicated
-        assert len(result["variables"]) == 2  # Both unique variables included (duplicate removed)
+        assert (
+            len(result["variables"]) == 2
+        )  # Both unique variables included (duplicate removed)
         assert "TradeExports_FRA" in [v["dcid"] for v in result["variables"]]
         assert "TradeImports_FRA" in [v["dcid"] for v in result["variables"]]
 
@@ -255,16 +265,16 @@ class TestSearchTopicsAndVariables:
     async def test_search_topics_and_variables_with_custom_per_search_limit(self):
         """Test search with custom per_search_limit parameter."""
         mock_client = Mock()
-        mock_client.fetch_topics_and_variables = AsyncMock(return_value={
-            "topics": [{"dcid": "topic/health"}],
-            "variables": [{"dcid": "Count_Person"}],
-            "lookups": {"topic/health": "Health", "Count_Person": "Population"}
-        })
+        mock_client.fetch_topics_and_variables = AsyncMock(
+            return_value={
+                "topics": [{"dcid": "topic/health"}],
+                "variables": [{"dcid": "Count_Person"}],
+                "lookups": {"topic/health": "Health", "Count_Person": "Population"},
+            }
+        )
 
         result = await search_topics_and_variables(
-            client=mock_client,
-            query="health",
-            per_search_limit=5
+            client=mock_client, query="health", per_search_limit=5
         )
 
         assert "topics" in result
@@ -281,36 +291,40 @@ class TestSearchTopicsAndVariables:
         mock_client = Mock()
 
         # Test invalid per_search_limit values
-        with pytest.raises(ValueError, match="per_search_limit must be between 1 and 100"):
+        with pytest.raises(
+            ValueError, match="per_search_limit must be between 1 and 100"
+        ):
             await search_topics_and_variables(
-                client=mock_client,
-                query="health",
-                per_search_limit=0
+                client=mock_client, query="health", per_search_limit=0
             )
 
-        with pytest.raises(ValueError, match="per_search_limit must be between 1 and 100"):
+        with pytest.raises(
+            ValueError, match="per_search_limit must be between 1 and 100"
+        ):
             await search_topics_and_variables(
-                client=mock_client,
-                query="health",
-                per_search_limit=101
+                client=mock_client, query="health", per_search_limit=101
             )
 
         # Test valid per_search_limit values
-        mock_client.fetch_topics_and_variables = AsyncMock(return_value={
-            "topics": [], "variables": [], "lookups": {}
-        })
+        mock_client.fetch_topics_and_variables = AsyncMock(
+            return_value={"topics": [], "variables": [], "lookups": {}}
+        )
 
         # Should not raise for valid values
-        await search_topics_and_variables(client=mock_client, query="health", per_search_limit=1)
-        await search_topics_and_variables(client=mock_client, query="health", per_search_limit=100)
+        await search_topics_and_variables(
+            client=mock_client, query="health", per_search_limit=1
+        )
+        await search_topics_and_variables(
+            client=mock_client, query="health", per_search_limit=100
+        )
 
     @pytest.mark.asyncio
     async def test_search_topics_and_variables_default_per_search_limit(self):
         """Test that default per_search_limit=10 is used when not specified."""
         mock_client = Mock()
-        mock_client.fetch_topics_and_variables = AsyncMock(return_value={
-            "topics": [], "variables": [], "lookups": {}
-        })
+        mock_client.fetch_topics_and_variables = AsyncMock(
+            return_value={"topics": [], "variables": [], "lookups": {}}
+        )
 
         await search_topics_and_variables(client=mock_client, query="health")
 

--- a/packages/datacommons-mcp/tests/test_settings.py
+++ b/packages/datacommons-mcp/tests/test_settings.py
@@ -24,35 +24,72 @@ from datacommons_mcp.data_models.settings import BaseDCSettings, CustomDCSetting
 from datacommons_mcp.settings import get_dc_settings
 
 
-class TestGetDCSettings:
-    """Test get_dc_settings function."""
+@pytest.fixture
+def isolated_env(tmp_path, monkeypatch):
+    """A fixture to isolate tests from .env files and existing env vars."""
+    monkeypatch.chdir(tmp_path)
+    # This inner function will be the fixture's return value
+    def _patch_env(env_vars):
+        return patch.dict(os.environ, env_vars, clear=True)
 
-    def test_get_dc_settings_base(self):
-        """Test base DC settings returns BaseDCSettings."""
-        with patch.dict(os.environ, {"DC_API_KEY": "test_key", "DC_TYPE": "base"}):
+    return _patch_env
+
+
+class TestBaseSettings:
+    """Test suite for loading BaseDCSettings."""
+
+    def test_loads_with_minimal_config(self, isolated_env):
+        """Tests that BaseDCSettings loads with minimal config and correct defaults."""
+        env_vars = {"DC_API_KEY": "test_key", "DC_TYPE": "base"}
+        with isolated_env(env_vars):
             settings = get_dc_settings()
 
             assert isinstance(settings, BaseDCSettings)
-            assert settings.dc_type == "base"
             assert settings.api_key == "test_key"
             assert settings.sv_search_base_url == "https://datacommons.org"
             assert settings.base_index == "base_uae_mem"
             assert settings.topic_cache_path is None
 
-    def test_get_dc_settings_custom(self):
-        """Test custom DC settings returns CustomDCSettings."""
-        with patch.dict(
-            os.environ,
-            {
-                "DC_API_KEY": "test_key",
-                "DC_TYPE": "custom",
-                "CUSTOM_DC_URL": "https://test.com",
-            },
-        ):
+    def test_loads_with_env_var_overrides(self, isolated_env):
+        """Tests that environment variables override defaults for BaseDCSettings."""
+        env_vars = {
+            "DC_API_KEY": "test_key",
+            "DC_TYPE": "base",
+            "DC_SV_SEARCH_BASE_URL": "https://custom.com",
+            "DC_BASE_INDEX": "custom_index",
+            "DC_TOPIC_CACHE_PATH": "/path/to/cache.json",
+        }
+        with isolated_env(env_vars):
+            settings = get_dc_settings()
+
+            assert isinstance(settings, BaseDCSettings)
+            assert settings.sv_search_base_url == "https://custom.com"
+            assert settings.base_index == "custom_index"
+            assert settings.topic_cache_path == "/path/to/cache.json"
+
+    def test_default_dc_type_is_base(self, isolated_env):
+        """Tests that DC_TYPE defaults to 'base' when not provided."""
+        env_vars = {"DC_API_KEY": "test_key"}
+        with isolated_env(env_vars):
+            settings = get_dc_settings()
+            assert isinstance(settings, BaseDCSettings)
+            assert settings.dc_type == "base"
+
+
+class TestCustomSettings:
+    """Test suite for loading CustomDCSettings."""
+
+    def test_loads_with_minimal_config(self, isolated_env):
+        """Tests that CustomDCSettings loads with minimal config and correct defaults."""
+        env_vars = {
+            "DC_API_KEY": "test_key",
+            "DC_TYPE": "custom",
+            "CUSTOM_DC_URL": "https://test.com",
+        }
+        with isolated_env(env_vars):
             settings = get_dc_settings()
 
             assert isinstance(settings, CustomDCSettings)
-            assert settings.dc_type == "custom"
             assert settings.api_key == "test_key"
             assert settings.custom_dc_url == "https://test.com"
             assert settings.api_base_url == "https://test.com/core/api/v2/"
@@ -61,187 +98,45 @@ class TestGetDCSettings:
             assert settings.custom_index == "user_all_minilm_mem"
             assert settings.root_topic_dcids is None
 
-    def test_get_dc_settings_missing_api_key(self):
-        """Test missing required API key raises error."""
-        with (
-            patch.dict(os.environ, {}, clear=True),
-            pytest.raises(ValueError, match="DC_API_KEY"),
-        ):
-            get_dc_settings()
-
-    def test_get_dc_settings_missing_custom_dc_url(self):
-        """Test missing custom DC URL for custom DC raises error."""
-        with (
-            patch.dict(os.environ, {"DC_API_KEY": "test_key", "DC_TYPE": "custom"}),
-            pytest.raises(ValueError, match="CUSTOM_DC_URL"),
-        ):
-            get_dc_settings()
-
-    def test_get_dc_settings_invalid_type(self):
-        """Test invalid DC type raises error."""
-        with (
-            patch.dict(os.environ, {"DC_API_KEY": "test_key", "DC_TYPE": "invalid"}),
-            pytest.raises(ValueError, match="Input should be 'base'"),
-        ):
-            get_dc_settings()
-
-    def test_get_dc_settings_defaults(self):
-        """Test that defaults are applied correctly."""
-        with patch.dict(os.environ, {"DC_API_KEY": "test_key", "DC_TYPE": "base"}):
+    def test_loads_with_env_var_overrides(self, isolated_env):
+        """Tests that environment variables override defaults for CustomDCSettings."""
+        env_vars = {
+            "DC_API_KEY": "test_key",
+            "DC_TYPE": "custom",
+            "CUSTOM_DC_URL": "https://test.com",
+            "DC_SEARCH_SCOPE": "custom_only",
+            "DC_BASE_INDEX": "custom_base",
+            "DC_CUSTOM_INDEX": "custom_custom",
+            "DC_ROOT_TOPIC_DCIDS": "topic1, topic2",
+        }
+        with isolated_env(env_vars):
             settings = get_dc_settings()
 
-            # Base DC defaults
-            assert settings.sv_search_base_url == "https://datacommons.org"
-            assert settings.base_index == "base_uae_mem"
-
-        with patch.dict(
-            os.environ,
-            {
-                "DC_API_KEY": "test_key",
-                "DC_TYPE": "custom",
-                "CUSTOM_DC_URL": "https://test.com",
-            },
-        ):
-            settings = get_dc_settings()
-
-            # Custom DC defaults
-            assert settings.search_scope == SearchScope.BASE_AND_CUSTOM
-            assert settings.base_index == "medium_ft"
-            assert settings.custom_index == "user_all_minilm_mem"
-
-    def test_get_dc_settings_environment_overrides(self):
-        """Test env vars override defaults."""
-        with patch.dict(
-            os.environ,
-            {
-                "DC_API_KEY": "test_key",
-                "DC_TYPE": "base",
-                "DC_SV_SEARCH_BASE_URL": "https://custom.com",
-                "DC_BASE_INDEX": "custom_index",
-            },
-        ):
-            settings = get_dc_settings()
-
-            assert settings.sv_search_base_url == "https://custom.com"
-            assert settings.base_index == "custom_index"
-
-        with patch.dict(
-            os.environ,
-            {
-                "DC_API_KEY": "test_key",
-                "DC_TYPE": "custom",
-                "CUSTOM_DC_URL": "https://test.com",
-                "DC_SEARCH_SCOPE": "base_only",
-                "DC_BASE_INDEX": "custom_base_index",
-                "DC_CUSTOM_INDEX": "custom_custom_index",
-            },
-        ):
-            settings = get_dc_settings()
-
-            assert settings.search_scope == SearchScope.BASE_ONLY
-            assert settings.base_index == "custom_base_index"
-            assert settings.custom_index == "custom_custom_index"
-
-    def test_get_dc_settings_search_scope_enum(self):
-        """Test SearchScope enum conversion."""
-        with patch.dict(
-            os.environ,
-            {
-                "DC_API_KEY": "test_key",
-                "DC_TYPE": "custom",
-                "CUSTOM_DC_URL": "https://test.com",
-                "DC_SEARCH_SCOPE": "custom_only",
-            },
-        ):
-            settings = get_dc_settings()
+            assert isinstance(settings, CustomDCSettings)
             assert settings.search_scope == SearchScope.CUSTOM_ONLY
+            assert settings.base_index == "custom_base"
+            assert settings.custom_index == "custom_custom"
+            assert settings.root_topic_dcids == ["topic1", "topic2"]
 
-        with patch.dict(
-            os.environ,
-            {
-                "DC_API_KEY": "test_key",
-                "DC_TYPE": "custom",
-                "CUSTOM_DC_URL": "https://test.com",
-                "DC_SEARCH_SCOPE": "base_only",
-            },
+    def test_missing_custom_url_raises_error(self, isolated_env):
+        """Tests that a ValueError is raised for custom type without CUSTOM_DC_URL."""
+        env_vars = {"DC_API_KEY": "test_key", "DC_TYPE": "custom"}
+        with isolated_env(env_vars), pytest.raises(ValueError, match="CUSTOM_DC_URL"):
+            get_dc_settings()
+
+
+class TestSettingsValidation:
+    """Test suite for generic settings validation."""
+
+    def test_missing_api_key_raises_error(self, isolated_env):
+        """Tests that a ValueError is raised if DC_API_KEY is missing."""
+        with isolated_env({}), pytest.raises(ValueError, match="DC_API_KEY"):
+            get_dc_settings()
+
+    def test_invalid_dc_type_raises_error(self, isolated_env):
+        """Tests that a ValueError is raised for an invalid DC_TYPE."""
+        env_vars = {"DC_API_KEY": "test_key", "DC_TYPE": "invalid"}
+        with isolated_env(env_vars), pytest.raises(
+            ValueError, match="Input should be 'base' or 'custom'"
         ):
-            settings = get_dc_settings()
-            assert settings.search_scope == SearchScope.BASE_ONLY
-
-    def test_get_dc_settings_root_topic_dcids(self):
-        """Test root topic DCIDs parsing."""
-        with patch.dict(
-            os.environ,
-            {
-                "DC_API_KEY": "test_key",
-                "DC_TYPE": "custom",
-                "CUSTOM_DC_URL": "https://test.com",
-                "DC_ROOT_TOPIC_DCIDS": "topic1,topic2,topic3",
-            },
-        ):
-            settings = get_dc_settings()
-            assert settings.root_topic_dcids == ["topic1", "topic2", "topic3"]
-
-    def test_get_dc_settings_topic_cache_path(self):
-        """Test topic cache path."""
-        with patch.dict(
-            os.environ,
-            {
-                "DC_API_KEY": "test_key",
-                "DC_TYPE": "base",
-                "DC_TOPIC_CACHE_PATH": "/path/to/cache.json",
-            },
-        ):
-            settings = get_dc_settings()
-            assert settings.topic_cache_path == "/path/to/cache.json"
-
-    def test_get_dc_settings_default_dc_type(self):
-        """Test that DC_TYPE defaults to 'base' when not provided."""
-        with patch.dict(os.environ, {"DC_API_KEY": "test_key"}):
-            settings = get_dc_settings()
-            assert settings.dc_type == "base"
-            assert isinstance(settings, BaseDCSettings)
-
-
-class TestSettingsClasses:
-    """Test settings classes directly."""
-
-    def test_base_dc_settings_direct(self):
-        """Test BaseDCSettings class directly."""
-        with patch.dict(os.environ, {"DC_API_KEY": "test_key", "DC_TYPE": "base"}):
-            settings = BaseDCSettings()
-
-            assert settings.dc_type == "base"
-            assert settings.api_key == "test_key"
-            assert settings.sv_search_base_url == "https://datacommons.org"
-            assert settings.base_index == "base_uae_mem"
-
-    def test_custom_dc_settings_direct(self):
-        """Test CustomDCSettings class directly."""
-        with patch.dict(
-            os.environ,
-            {
-                "DC_API_KEY": "test_key",
-                "DC_TYPE": "custom",
-                "CUSTOM_DC_URL": "https://test.com",
-            },
-        ):
-            settings = CustomDCSettings()
-
-            assert settings.dc_type == "custom"
-            assert settings.api_key == "test_key"
-            assert settings.custom_dc_url == "https://test.com"
-            assert settings.api_base_url == "https://test.com/core/api/v2/"
-
-    def test_settings_field_aliases(self):
-        """Test that field aliases work correctly."""
-        with patch.dict(
-            os.environ,
-            {
-                "DC_API_KEY": "test_key",
-                "DC_TYPE": "base",
-                "DC_SV_SEARCH_BASE_URL": "https://custom.com",
-            },
-        ):
-            settings = BaseDCSettings()
-            assert settings.sv_search_base_url == "https://custom.com"
+            get_dc_settings()

--- a/packages/datacommons-mcp/tests/test_settings.py
+++ b/packages/datacommons-mcp/tests/test_settings.py
@@ -16,12 +16,12 @@ Tests for settings module.
 """
 
 import os
-import pytest
 from unittest.mock import patch
 
-from datacommons_mcp.settings import get_dc_settings
-from datacommons_mcp.data_models.settings import BaseDCSettings, CustomDCSettings
+import pytest
 from datacommons_mcp.data_models.enums import SearchScope
+from datacommons_mcp.data_models.settings import BaseDCSettings, CustomDCSettings
+from datacommons_mcp.settings import get_dc_settings
 
 
 class TestGetDCSettings:
@@ -29,161 +29,168 @@ class TestGetDCSettings:
 
     def test_get_dc_settings_base(self):
         """Test base DC settings returns BaseDCSettings."""
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'base'
-        }):
+        with patch.dict(os.environ, {"DC_API_KEY": "test_key", "DC_TYPE": "base"}):
             settings = get_dc_settings()
-            
+
             assert isinstance(settings, BaseDCSettings)
-            assert settings.dc_type == 'base'
-            assert settings.api_key == 'test_key'
-            assert settings.sv_search_base_url == 'https://datacommons.org'
-            assert settings.base_index == 'base_uae_mem'
+            assert settings.dc_type == "base"
+            assert settings.api_key == "test_key"
+            assert settings.sv_search_base_url == "https://datacommons.org"
+            assert settings.base_index == "base_uae_mem"
             assert settings.topic_cache_path is None
 
     def test_get_dc_settings_custom(self):
         """Test custom DC settings returns CustomDCSettings."""
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'custom',
-            'CUSTOM_DC_URL': 'https://test.com'
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "DC_API_KEY": "test_key",
+                "DC_TYPE": "custom",
+                "CUSTOM_DC_URL": "https://test.com",
+            },
+        ):
             settings = get_dc_settings()
-            
+
             assert isinstance(settings, CustomDCSettings)
-            assert settings.dc_type == 'custom'
-            assert settings.api_key == 'test_key'
-            assert settings.custom_dc_url == 'https://test.com'
-            assert settings.api_base_url == 'https://test.com/core/api/v2/'
+            assert settings.dc_type == "custom"
+            assert settings.api_key == "test_key"
+            assert settings.custom_dc_url == "https://test.com"
+            assert settings.api_base_url == "https://test.com/core/api/v2/"
             assert settings.search_scope == SearchScope.BASE_AND_CUSTOM
-            assert settings.base_index == 'medium_ft'
-            assert settings.custom_index == 'user_all_minilm_mem'
+            assert settings.base_index == "medium_ft"
+            assert settings.custom_index == "user_all_minilm_mem"
             assert settings.root_topic_dcids is None
 
     def test_get_dc_settings_missing_api_key(self):
         """Test missing required API key raises error."""
-        with patch.dict(os.environ, {}, clear=True):
-            with pytest.raises(ValueError, match="DC_API_KEY"):
+        with patch.dict(os.environ, {}, clear=True), pytest.raises(ValueError, match="DC_API_KEY"):
                 get_dc_settings()
 
     def test_get_dc_settings_missing_custom_dc_url(self):
         """Test missing custom DC URL for custom DC raises error."""
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'custom'
-        }):
-            with pytest.raises(ValueError, match="CUSTOM_DC_URL"):
+        with patch.dict(os.environ, {"DC_API_KEY": "test_key", "DC_TYPE": "custom"}), pytest.raises(ValueError, match="CUSTOM_DC_URL"):
                 get_dc_settings()
 
     def test_get_dc_settings_invalid_type(self):
         """Test invalid DC type raises error."""
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'invalid'
-        }):
-            with pytest.raises(ValueError, match="Input should be 'base'"):
+        with patch.dict(os.environ, {"DC_API_KEY": "test_key", "DC_TYPE": "invalid"}), pytest.raises(ValueError, match="Input should be 'base'"):
                 get_dc_settings()
 
     def test_get_dc_settings_defaults(self):
         """Test that defaults are applied correctly."""
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'base'
-        }):
+        with patch.dict(os.environ, {"DC_API_KEY": "test_key", "DC_TYPE": "base"}):
             settings = get_dc_settings()
-            
+
             # Base DC defaults
-            assert settings.sv_search_base_url == 'https://datacommons.org'
-            assert settings.base_index == 'base_uae_mem'
-            
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'custom',
-            'CUSTOM_DC_URL': 'https://test.com'
-        }):
+            assert settings.sv_search_base_url == "https://datacommons.org"
+            assert settings.base_index == "base_uae_mem"
+
+        with patch.dict(
+            os.environ,
+            {
+                "DC_API_KEY": "test_key",
+                "DC_TYPE": "custom",
+                "CUSTOM_DC_URL": "https://test.com",
+            },
+        ):
             settings = get_dc_settings()
-            
+
             # Custom DC defaults
             assert settings.search_scope == SearchScope.BASE_AND_CUSTOM
-            assert settings.base_index == 'medium_ft'
-            assert settings.custom_index == 'user_all_minilm_mem'
+            assert settings.base_index == "medium_ft"
+            assert settings.custom_index == "user_all_minilm_mem"
 
     def test_get_dc_settings_environment_overrides(self):
         """Test env vars override defaults."""
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'base',
-            'DC_SV_SEARCH_BASE_URL': 'https://custom.com',
-            'DC_BASE_INDEX': 'custom_index'
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "DC_API_KEY": "test_key",
+                "DC_TYPE": "base",
+                "DC_SV_SEARCH_BASE_URL": "https://custom.com",
+                "DC_BASE_INDEX": "custom_index",
+            },
+        ):
             settings = get_dc_settings()
-            
-            assert settings.sv_search_base_url == 'https://custom.com'
-            assert settings.base_index == 'custom_index'
-            
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'custom',
-            'CUSTOM_DC_URL': 'https://test.com',
-            'DC_SEARCH_SCOPE': 'base_only',
-            'DC_BASE_INDEX': 'custom_base_index',
-            'DC_CUSTOM_INDEX': 'custom_custom_index'
-        }):
+
+            assert settings.sv_search_base_url == "https://custom.com"
+            assert settings.base_index == "custom_index"
+
+        with patch.dict(
+            os.environ,
+            {
+                "DC_API_KEY": "test_key",
+                "DC_TYPE": "custom",
+                "CUSTOM_DC_URL": "https://test.com",
+                "DC_SEARCH_SCOPE": "base_only",
+                "DC_BASE_INDEX": "custom_base_index",
+                "DC_CUSTOM_INDEX": "custom_custom_index",
+            },
+        ):
             settings = get_dc_settings()
-            
+
             assert settings.search_scope == SearchScope.BASE_ONLY
-            assert settings.base_index == 'custom_base_index'
-            assert settings.custom_index == 'custom_custom_index'
+            assert settings.base_index == "custom_base_index"
+            assert settings.custom_index == "custom_custom_index"
 
     def test_get_dc_settings_search_scope_enum(self):
         """Test SearchScope enum conversion."""
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'custom',
-            'CUSTOM_DC_URL': 'https://test.com',
-            'DC_SEARCH_SCOPE': 'custom_only'
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "DC_API_KEY": "test_key",
+                "DC_TYPE": "custom",
+                "CUSTOM_DC_URL": "https://test.com",
+                "DC_SEARCH_SCOPE": "custom_only",
+            },
+        ):
             settings = get_dc_settings()
             assert settings.search_scope == SearchScope.CUSTOM_ONLY
-            
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'custom',
-            'CUSTOM_DC_URL': 'https://test.com',
-            'DC_SEARCH_SCOPE': 'base_only'
-        }):
+
+        with patch.dict(
+            os.environ,
+            {
+                "DC_API_KEY": "test_key",
+                "DC_TYPE": "custom",
+                "CUSTOM_DC_URL": "https://test.com",
+                "DC_SEARCH_SCOPE": "base_only",
+            },
+        ):
             settings = get_dc_settings()
             assert settings.search_scope == SearchScope.BASE_ONLY
 
     def test_get_dc_settings_root_topic_dcids(self):
         """Test root topic DCIDs parsing."""
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'custom',
-            'CUSTOM_DC_URL': 'https://test.com',
-            'DC_ROOT_TOPIC_DCIDS': 'topic1,topic2,topic3'
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "DC_API_KEY": "test_key",
+                "DC_TYPE": "custom",
+                "CUSTOM_DC_URL": "https://test.com",
+                "DC_ROOT_TOPIC_DCIDS": "topic1,topic2,topic3",
+            },
+        ):
             settings = get_dc_settings()
-            assert settings.root_topic_dcids == ['topic1', 'topic2', 'topic3']
+            assert settings.root_topic_dcids == ["topic1", "topic2", "topic3"]
 
     def test_get_dc_settings_topic_cache_path(self):
         """Test topic cache path."""
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'base',
-            'DC_TOPIC_CACHE_PATH': '/path/to/cache.json'
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "DC_API_KEY": "test_key",
+                "DC_TYPE": "base",
+                "DC_TOPIC_CACHE_PATH": "/path/to/cache.json",
+            },
+        ):
             settings = get_dc_settings()
-            assert settings.topic_cache_path == '/path/to/cache.json'
+            assert settings.topic_cache_path == "/path/to/cache.json"
 
     def test_get_dc_settings_default_dc_type(self):
         """Test that DC_TYPE defaults to 'base' when not provided."""
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key'
-        }):
+        with patch.dict(os.environ, {"DC_API_KEY": "test_key"}):
             settings = get_dc_settings()
-            assert settings.dc_type == 'base'
+            assert settings.dc_type == "base"
             assert isinstance(settings, BaseDCSettings)
 
 
@@ -192,37 +199,40 @@ class TestSettingsClasses:
 
     def test_base_dc_settings_direct(self):
         """Test BaseDCSettings class directly."""
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'base'
-        }):
+        with patch.dict(os.environ, {"DC_API_KEY": "test_key", "DC_TYPE": "base"}):
             settings = BaseDCSettings()
-            
-            assert settings.dc_type == 'base'
-            assert settings.api_key == 'test_key'
-            assert settings.sv_search_base_url == 'https://datacommons.org'
-            assert settings.base_index == 'base_uae_mem'
+
+            assert settings.dc_type == "base"
+            assert settings.api_key == "test_key"
+            assert settings.sv_search_base_url == "https://datacommons.org"
+            assert settings.base_index == "base_uae_mem"
 
     def test_custom_dc_settings_direct(self):
         """Test CustomDCSettings class directly."""
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'custom',
-            'CUSTOM_DC_URL': 'https://test.com'
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "DC_API_KEY": "test_key",
+                "DC_TYPE": "custom",
+                "CUSTOM_DC_URL": "https://test.com",
+            },
+        ):
             settings = CustomDCSettings()
-            
-            assert settings.dc_type == 'custom'
-            assert settings.api_key == 'test_key'
-            assert settings.custom_dc_url == 'https://test.com'
-            assert settings.api_base_url == 'https://test.com/core/api/v2/'
+
+            assert settings.dc_type == "custom"
+            assert settings.api_key == "test_key"
+            assert settings.custom_dc_url == "https://test.com"
+            assert settings.api_base_url == "https://test.com/core/api/v2/"
 
     def test_settings_field_aliases(self):
         """Test that field aliases work correctly."""
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'base',
-            'DC_SV_SEARCH_BASE_URL': 'https://custom.com'
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "DC_API_KEY": "test_key",
+                "DC_TYPE": "base",
+                "DC_SV_SEARCH_BASE_URL": "https://custom.com",
+            },
+        ):
             settings = BaseDCSettings()
-            assert settings.sv_search_base_url == 'https://custom.com'
+            assert settings.sv_search_base_url == "https://custom.com"

--- a/packages/datacommons-mcp/tests/test_settings.py
+++ b/packages/datacommons-mcp/tests/test_settings.py
@@ -28,6 +28,7 @@ from datacommons_mcp.settings import get_dc_settings
 def isolated_env(tmp_path, monkeypatch):
     """A fixture to isolate tests from .env files and existing env vars."""
     monkeypatch.chdir(tmp_path)
+
     # This inner function will be the fixture's return value
     def _patch_env(env_vars):
         return patch.dict(os.environ, env_vars, clear=True)
@@ -136,7 +137,8 @@ class TestSettingsValidation:
     def test_invalid_dc_type_raises_error(self, isolated_env):
         """Tests that a ValueError is raised for an invalid DC_TYPE."""
         env_vars = {"DC_API_KEY": "test_key", "DC_TYPE": "invalid"}
-        with isolated_env(env_vars), pytest.raises(
-            ValueError, match="Input should be 'base' or 'custom'"
+        with (
+            isolated_env(env_vars),
+            pytest.raises(ValueError, match="Input should be 'base' or 'custom'"),
         ):
             get_dc_settings()

--- a/packages/datacommons-mcp/tests/test_settings.py
+++ b/packages/datacommons-mcp/tests/test_settings.py
@@ -63,18 +63,27 @@ class TestGetDCSettings:
 
     def test_get_dc_settings_missing_api_key(self):
         """Test missing required API key raises error."""
-        with patch.dict(os.environ, {}, clear=True), pytest.raises(ValueError, match="DC_API_KEY"):
-                get_dc_settings()
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(ValueError, match="DC_API_KEY"),
+        ):
+            get_dc_settings()
 
     def test_get_dc_settings_missing_custom_dc_url(self):
         """Test missing custom DC URL for custom DC raises error."""
-        with patch.dict(os.environ, {"DC_API_KEY": "test_key", "DC_TYPE": "custom"}), pytest.raises(ValueError, match="CUSTOM_DC_URL"):
-                get_dc_settings()
+        with (
+            patch.dict(os.environ, {"DC_API_KEY": "test_key", "DC_TYPE": "custom"}),
+            pytest.raises(ValueError, match="CUSTOM_DC_URL"),
+        ):
+            get_dc_settings()
 
     def test_get_dc_settings_invalid_type(self):
         """Test invalid DC type raises error."""
-        with patch.dict(os.environ, {"DC_API_KEY": "test_key", "DC_TYPE": "invalid"}), pytest.raises(ValueError, match="Input should be 'base'"):
-                get_dc_settings()
+        with (
+            patch.dict(os.environ, {"DC_API_KEY": "test_key", "DC_TYPE": "invalid"}),
+            pytest.raises(ValueError, match="Input should be 'base'"),
+        ):
+            get_dc_settings()
 
     def test_get_dc_settings_defaults(self):
         """Test that defaults are applied correctly."""

--- a/packages/datacommons-mcp/tests/test_settings.py
+++ b/packages/datacommons-mcp/tests/test_settings.py
@@ -45,7 +45,6 @@ class TestBaseSettings:
         with isolated_env(env_vars):
             settings = get_dc_settings()
 
-
             assert isinstance(settings, BaseDCSettings)
             assert settings.api_key == "test_key"
             assert settings.sv_search_base_url == "https://datacommons.org"

--- a/packages/datacommons-test-agents/datacommons_test_agents/basic_agent/agent.py
+++ b/packages/datacommons-test-agents/datacommons_test_agents/basic_agent/agent.py
@@ -10,8 +10,8 @@ import os
 from google.adk.agents.llm_agent import LlmAgent
 from google.adk.tools.mcp_tool.mcp_toolset import (
     MCPToolset,
-    StdioServerParameters,
     StdioConnectionParams,
+    StdioServerParameters,
 )
 
 from .instructions import AGENT_INSTRUCTIONS

--- a/packages/datacommons-test-agents/datacommons_test_agents/basic_agent/evals/agent_test.py
+++ b/packages/datacommons-test-agents/datacommons_test_agents/basic_agent/evals/agent_test.py
@@ -1,15 +1,18 @@
 import pathlib
-from google.adk.evaluation.agent_evaluator import AgentEvaluator
+
 import pytest
+from google.adk.evaluation.agent_evaluator import AgentEvaluator
 
 parent_path = pathlib.Path(__file__).parent
 
 
 @pytest.mark.asyncio
-async def test_basic_agent():
+async def test_basic_agent() -> None:
     """Test the agent's basic ability via a session file."""
     await AgentEvaluator.evaluate(
         agent_module="datacommons_test_agents.basic_agent.bootstrap",
-        eval_dataset_file_path_or_dir=str(parent_path / "data/get_observations.test.json"),
+        eval_dataset_file_path_or_dir=str(
+            parent_path / "data/get_observations.test.json"
+        ),
         num_runs=2,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   "ruff>=0.12.5",
   "pytest>=8.4.1",
   "pytest-asyncio>=1.1.0",
+  "pre-commit>=4.3.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -168,6 +168,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114, upload-time = "2023-08-12T20:38:17.776Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249, upload-time = "2023-08-12T20:38:16.269Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -276,6 +285,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "datacommons-mcp" },
     { name = "datacommons-test-agents" },
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -291,6 +301,7 @@ test = [
 requires-dist = [
     { name = "datacommons-mcp", editable = "packages/datacommons-mcp" },
     { name = "datacommons-test-agents", editable = "packages/datacommons-test-agents" },
+    { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.4.1" },
     { name = "pytest-asyncio", specifier = ">=1.1.0" },
@@ -350,6 +361,15 @@ requires-dist = [
     { name = "datacommons-mcp", editable = "packages/datacommons-mcp" },
     { name = "google-adk" },
     { name = "google-adk", extras = ["eval"] },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
 ]
 
 [[package]]
@@ -1035,6 +1055,15 @@ wheels = [
 ]
 
 [[package]]
+name = "identify"
+version = "2.6.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ca/ffbabe3635bb839aa36b3a893c91a9b0d368cb4d8073e03a12896970af82/identify-2.6.13.tar.gz", hash = "sha256:da8d6c828e773620e13bfa86ea601c5a5310ba4bcd65edf378198b56a1f9fb32", size = 99243, upload-time = "2025-08-09T19:35:00.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/ce/461b60a3ee109518c055953729bf9ed089a04db895d47e95444071dcdef2/identify-2.6.13-py2.py3-none-any.whl", hash = "sha256:60381139b3ae39447482ecc406944190f690d4a2997f2584062089848361b33b", size = 99153, upload-time = "2025-08-09T19:34:59.1Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
@@ -1302,6 +1331,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1519,12 +1557,37 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/e8/21db9c9987b0e728855bd57bff6984f67952bea55d6f75e055c46b5383e8/platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf", size = 21634, upload-time = "2025-08-26T14:32:04.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/4b/2028861e724d3bd36227adfa20d3fd24c3fc6d52032f4a93c133be5d17ce/platformdirs-4.4.0-py3-none-any.whl", hash = "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85", size = 18654, upload-time = "2025-08-26T14:32:02.735Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/29/7cf5bbc236333876e4b41f56e06857a87937ce4bf91e117a6991a2dbb02a/pre_commit-4.3.0.tar.gz", hash = "sha256:499fe450cc9d42e9d58e606262795ecb64dd05438943c62b66f6a8673da30b16", size = 193792, upload-time = "2025-08-09T18:56:14.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/a5/987a405322d78a73b66e39e4a90e4ef156fd7141bf71df987e50717c321b/pre_commit-4.3.0-py2.py3-none-any.whl", hash = "sha256:2b0747ad7e6e967169136edffee14c16e148a778a54e4f967921aa1ebf2308d8", size = 220965, upload-time = "2025-08-09T18:56:13.192Z" },
 ]
 
 [[package]]
@@ -2250,6 +2313,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/42/e0e305207bb88c6b8d3061399c6a961ffe5fbb7e2aa63c9234df7259e9cd/uvicorn-0.35.0.tar.gz", hash = "sha256:bc662f087f7cf2ce11a1d7fd70b90c9f98ef2e2831556dd078d131b96cc94a01", size = 78473, upload-time = "2025-06-28T16:15:46.058Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/e2/dc81b1bd1dcfe91735810265e9d26bc8ec5da45b4c0f6237e286819194c3/uvicorn-0.35.0-py3-none-any.whl", hash = "sha256:197535216b25ff9b785e29a0b79199f55222193d47f820816e7da751e9bc8d4a", size = 66406, upload-time = "2025-06-28T16:15:44.816Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "20.34.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/14/37fcdba2808a6c615681cd216fecae00413c9dab44fb2e57805ecf3eaee3/virtualenv-20.34.0.tar.gz", hash = "sha256:44815b2c9dee7ed86e387b842a84f20b93f7f417f95886ca1996a72a4138eb1a", size = 6003808, upload-time = "2025-08-13T14:24:07.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/06/04c8e804f813cf972e3262f3f8584c232de64f0cde9f703b46cf53a45090/virtualenv-20.34.0-py3-none-any.whl", hash = "sha256:341f5afa7eee943e4984a9207c025feedd768baff6753cd660c857ceb3e36026", size = 5983279, upload-time = "2025-08-13T14:24:05.111Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Currently running pytest with a local .env file providing an api key causes test_settings:test_missing_api_key_raises_error to fail since the api key gets loaded. This PR introduces a pytest fixture to create an isolated environment that won't pickup local .env files when running tests.

This PR also formats files using uv run ruff format and fixes some errors when running uv run ruff check. This includes using a logger instead of logging to root.