### PR TITLE
[cleanup] Run ruff formatter

### DIFF
--- a/packages/datacommons-mcp/datacommons_mcp/data_models/enums.py
+++ b/packages/datacommons-mcp/datacommons_mcp/data_models/enums.py
@@ -21,6 +21,7 @@ from enum import Enum
 
 class SearchScope(Enum):
     """Enum for controlling search scope in Data Commons queries."""
+
     CUSTOM_ONLY = "custom_only"
     BASE_ONLY = "base_only"
     BASE_AND_CUSTOM = "base_and_custom"

--- a/packages/datacommons-mcp/datacommons_mcp/data_models/search.py
+++ b/packages/datacommons-mcp/datacommons_mcp/data_models/search.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, Field
 
 class SearchMode(str, Enum):
     """Enumeration of search modes for the search_indicators tool."""
-    
+
     BROWSE = "browse"
     LOOKUP = "lookup"
 
@@ -23,40 +23,60 @@ SearchModeType = Literal["browse", "lookup"]
 
 class SearchTask(BaseModel):
     """Represents a single search task with query and place filters."""
-    
+
     query: str = Field(description="The search query string")
-    place_dcids: list[str] = Field(default_factory=list, description="List of place DCIDs to filter by")
+    place_dcids: list[str] = Field(
+        default_factory=list, description="List of place DCIDs to filter by"
+    )
 
 
 class SearchVariable(BaseModel):
     """Represents a variable object in search results."""
-    
+
     dcid: str = Field(description="Variable DCID")
-    places_with_data: list[str] = Field(default_factory=list, description="Place DCIDs where data exists")
+    places_with_data: list[str] = Field(
+        default_factory=list, description="Place DCIDs where data exists"
+    )
 
 
 class SearchTopic(BaseModel):
     """Represents a topic object in search results."""
-    
+
     dcid: str = Field(description="Topic DCID")
-    member_topics: list[str] = Field(default_factory=list, description="Direct member topic DCIDs")
-    member_variables: list[str] = Field(default_factory=list, description="Direct member variable DCIDs")
-    places_with_data: list[str] | None = Field(None, description="Place DCIDs where data exists (if place filtering was performed)")
+    member_topics: list[str] = Field(
+        default_factory=list, description="Direct member topic DCIDs"
+    )
+    member_variables: list[str] = Field(
+        default_factory=list, description="Direct member variable DCIDs"
+    )
+    places_with_data: list[str] | None = Field(
+        None,
+        description="Place DCIDs where data exists (if place filtering was performed)",
+    )
 
 
 class SearchResult(BaseModel):
     """Represents intermediate results from DCClient."""
-    
-    topics: dict[str, SearchTopic] = Field(default_factory=dict, description="Map of topic DCID to SearchTopic")
-    variables: dict[str, SearchVariable] = Field(default_factory=dict, description="Map of variable DCID to SearchVariable")
+
+    topics: dict[str, SearchTopic] = Field(
+        default_factory=dict, description="Map of topic DCID to SearchTopic"
+    )
+    variables: dict[str, SearchVariable] = Field(
+        default_factory=dict, description="Map of variable DCID to SearchVariable"
+    )
 
 
 class SearchResponse(BaseModel):
-    """Unified response model for search operations.
-    """
-    
-    topics: list[SearchTopic] | None = Field(None, description="List of topic objects (browse mode only)")
-    variables: list[SearchVariable] = Field(description="List of variable objects with dcid and places_with_data")
-    lookups: dict[str, str] = Field(default_factory=dict, description="DCID to name mappings")
-    
+    """Unified response model for search operations."""
+
+    topics: list[SearchTopic] | None = Field(
+        None, description="List of topic objects (browse mode only)"
+    )
+    variables: list[SearchVariable] = Field(
+        description="List of variable objects with dcid and places_with_data"
+    )
+    lookups: dict[str, str] = Field(
+        default_factory=dict, description="DCID to name mappings"
+    )
+
     status: str = Field(default="SUCCESS", description="Status of the search operation")

--- a/packages/datacommons-mcp/datacommons_mcp/data_models/settings.py
+++ b/packages/datacommons-mcp/datacommons_mcp/data_models/settings.py
@@ -22,106 +22,94 @@ from pydantic_settings import BaseSettings
 
 from .enums import SearchScope
 
-_MODEL_CONFIG = {
-    "env_file": ".env",
-    "extra": "ignore"
-}
+_MODEL_CONFIG = {"env_file": ".env", "extra": "ignore"}
 
 
 class DCSettingsSelector(BaseSettings):
     """Settings selector to determine DC type from environment."""
-    
+
     model_config = _MODEL_CONFIG
-    
+
     dc_type: Literal["base", "custom"] = Field(
-        default="base",
-        alias="DC_TYPE",
-        description="Type of Data Commons"
+        default="base", alias="DC_TYPE", description="Type of Data Commons"
     )
 
 
 class BaseDCSettings(BaseSettings):
     """Settings for base Data Commons instance."""
-    
+
     model_config = _MODEL_CONFIG
-    
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-    
+
     dc_type: Literal["base"] = Field(
         default="base",
         alias="DC_TYPE",
-        description="Type of Data Commons (must be 'base')"
+        description="Type of Data Commons (must be 'base')",
     )
-    api_key: str = Field(
-        alias="DC_API_KEY",
-        description="API key for Data Commons"
-    )
+    api_key: str = Field(alias="DC_API_KEY", description="API key for Data Commons")
     sv_search_base_url: str = Field(
         default="https://datacommons.org",
         alias="DC_SV_SEARCH_BASE_URL",
-        description="Search base URL for base DC"
+        description="Search base URL for base DC",
     )
     base_index: str = Field(
         default="base_uae_mem",
         alias="DC_BASE_INDEX",
-        description="Search index for base DC"
+        description="Search index for base DC",
     )
     topic_cache_path: str | None = Field(
         default=None,
         alias="DC_TOPIC_CACHE_PATH",
-        description="Path to topic cache file"
+        description="Path to topic cache file",
     )
 
 
 class CustomDCSettings(BaseSettings):
     """Settings for custom Data Commons instance."""
-    
+
     model_config = _MODEL_CONFIG
-    
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-    
+
     dc_type: Literal["custom"] = Field(
         default="custom",
         alias="DC_TYPE",
-        description="Type of Data Commons (must be 'custom')"
+        description="Type of Data Commons (must be 'custom')",
     )
-    api_key: str = Field(
-        alias="DC_API_KEY",
-        description="API key for Data Commons"
-    )
+    api_key: str = Field(alias="DC_API_KEY", description="API key for Data Commons")
     custom_dc_url: str = Field(
-        alias="CUSTOM_DC_URL",
-        description="Base URL for custom Data Commons instance"
+        alias="CUSTOM_DC_URL", description="Base URL for custom Data Commons instance"
     )
     api_base_url: str | None = Field(
         default=None,
         alias="DC_API_BASE_URL",
-        description="API base URL (computed from base_url if not provided)"
+        description="API base URL (computed from base_url if not provided)",
     )
     search_scope: SearchScope = Field(
         default=SearchScope.BASE_AND_CUSTOM,
         alias="DC_SEARCH_SCOPE",
-        description="Search scope for queries"
+        description="Search scope for queries",
     )
     base_index: str = Field(
         default="medium_ft",
         alias="DC_BASE_INDEX",
-        description="Search index for base DC"
+        description="Search index for base DC",
     )
     custom_index: str = Field(
         default="user_all_minilm_mem",
         alias="DC_CUSTOM_INDEX",
-        description="Search index for custom DC"
+        description="Search index for custom DC",
     )
     root_topic_dcids: list[str] | None = Field(
         default=None,
         alias="DC_ROOT_TOPIC_DCIDS",
-        description="List of root topic DCIDs"
+        description="List of root topic DCIDs",
     )
-    
-    @field_validator('root_topic_dcids', mode='before')
+
+    @field_validator("root_topic_dcids", mode="before")
     @classmethod
     def parse_root_topic_dcids(cls, v):
         """Parse comma-separated string into list of strings."""
@@ -133,9 +121,9 @@ class CustomDCSettings(BaseSettings):
             # Filter out empty items
             return [item for item in items if item]
         return v
-    
-    @model_validator(mode='after')
-    def compute_api_base_url(self) -> 'CustomDCSettings':
+
+    @model_validator(mode="after")
+    def compute_api_base_url(self) -> "CustomDCSettings":
         """Compute api_base_url from custom_dc_url if not provided."""
         if self.api_base_url is None:
             self.api_base_url = self.custom_dc_url.rstrip("/") + "/core/api/v2/"

--- a/packages/datacommons-mcp/datacommons_mcp/server.py
+++ b/packages/datacommons-mcp/datacommons_mcp/server.py
@@ -36,7 +36,10 @@ from datacommons_mcp.data_models.charts import (
 from datacommons_mcp.data_models.observations import (
     ObservationToolResponse,
 )
-from datacommons_mcp.services import get_observations as get_observations_service, search_indicators as search_indicators_service
+from datacommons_mcp.services import (
+    get_observations as get_observations_service,
+    search_indicators as search_indicators_service,
+)
 from datacommons_mcp.data_models.search import SearchMode, SearchModeType
 
 
@@ -198,9 +201,6 @@ async def validate_child_place_types(
     return dict(zip(child_place_types, results, strict=False))
 
 
-
-
-
 @mcp.tool()
 async def get_datacommons_chart_config(
     chart_type: str,
@@ -354,9 +354,6 @@ async def get_datacommons_chart_config(
         raise ValueError(f"Validation failed for chart_type '{chart_type}': {e}") from e
 
 
-
-
-
 @mcp.tool()
 async def search_indicators(
     query: str,
@@ -464,7 +461,6 @@ async def search_indicators(
     - Both modes support place filtering and bilateral queries
     - Both modes use sophisticated query rewriting logic for optimal results
     """
-    return await search_indicators_service(dc_client, query, mode, place1_name, place2_name, per_search_limit)
-
-
-
+    return await search_indicators_service(
+        dc_client, query, mode, place1_name, place2_name, per_search_limit
+    )

--- a/packages/datacommons-mcp/datacommons_mcp/settings.py
+++ b/packages/datacommons-mcp/datacommons_mcp/settings.py
@@ -15,26 +15,30 @@
 Settings module for Data Commons clients.
 """
 
-from .data_models.settings import BaseDCSettings, CustomDCSettings, DCSettings, DCSettingsSelector
+from .data_models.settings import (
+    BaseDCSettings,
+    CustomDCSettings,
+    DCSettings,
+    DCSettingsSelector,
+)
 
 
 def get_dc_settings() -> DCSettings:
     """
     Get Data Commons settings from environment variables.
-    
+
     Automatically loads from .env file if present.
-    
+
     Returns:
         DCSettings object containing the configuration
-        
+
     Raises:
         ValueError: If required configuration is missing or invalid
     """
 
-    
     # First, determine the DC type using the settings selector
     settings_selector = DCSettingsSelector()
-    
+
     # Create the appropriate settings class based on the type
     if settings_selector.dc_type == "custom":
         return CustomDCSettings()

--- a/packages/datacommons-mcp/tests/test_dc_client.py
+++ b/packages/datacommons-mcp/tests/test_dc_client.py
@@ -91,7 +91,7 @@ class TestDCClientConstructor:
             dc=mocked_datacommons_client,
             search_scope=SearchScope.CUSTOM_ONLY,
             base_index="medium_ft",
-            custom_index="user_all_minilm_mem"
+            custom_index="user_all_minilm_mem",
         )
 
         # Assert: Verify the client is configured correctly
@@ -110,35 +110,45 @@ class TestDCClientConstructor:
             dc=mocked_datacommons_client,
             search_scope=SearchScope.BASE_AND_CUSTOM,
             base_index="medium_ft",
-            custom_index="user_all_minilm_mem"
+            custom_index="user_all_minilm_mem",
         )
 
         # Assert: Verify the client is configured correctly
         assert client_under_test.search_scope == SearchScope.BASE_AND_CUSTOM
         assert client_under_test.search_indices == ["user_all_minilm_mem", "medium_ft"]
 
-    def test_compute_search_indices_validation_custom_only_without_index(self, mocked_datacommons_client):
+    def test_compute_search_indices_validation_custom_only_without_index(
+        self, mocked_datacommons_client
+    ):
         """
         Test that CUSTOM_ONLY search scope without custom_index raises ValueError.
         """
         # Arrange & Act & Assert: Creating client with invalid configuration should raise ValueError
-        with pytest.raises(ValueError, match="Custom index not configured but CUSTOM_ONLY search scope requested"):
+        with pytest.raises(
+            ValueError,
+            match="Custom index not configured but CUSTOM_ONLY search scope requested",
+        ):
             DCClient(
                 dc=mocked_datacommons_client,
                 search_scope=SearchScope.CUSTOM_ONLY,
-                custom_index=None
+                custom_index=None,
             )
 
-    def test_compute_search_indices_validation_custom_only_with_empty_index(self, mocked_datacommons_client):
+    def test_compute_search_indices_validation_custom_only_with_empty_index(
+        self, mocked_datacommons_client
+    ):
         """
         Test that CUSTOM_ONLY search scope with empty custom_index raises ValueError.
         """
         # Arrange & Act & Assert: Creating client with invalid configuration should raise ValueError
-        with pytest.raises(ValueError, match="Custom index not configured but CUSTOM_ONLY search scope requested"):
+        with pytest.raises(
+            ValueError,
+            match="Custom index not configured but CUSTOM_ONLY search scope requested",
+        ):
             DCClient(
                 dc=mocked_datacommons_client,
                 search_scope=SearchScope.CUSTOM_ONLY,
-                custom_index=""
+                custom_index="",
             )
 
 
@@ -146,8 +156,10 @@ class TestDCClientSearch:
     """Tests for the search_svs method of DCClient."""
 
     @pytest.mark.asyncio
-    @patch('datacommons_mcp.clients.requests.post')
-    async def test_search_svs_single_api_call(self, mock_post, mocked_datacommons_client):
+    @patch("datacommons_mcp.clients.requests.post")
+    async def test_search_svs_single_api_call(
+        self, mock_post, mocked_datacommons_client
+    ):
         """
         Test that search_svs makes a single API call with comma-separated indices.
         """
@@ -156,16 +168,13 @@ class TestDCClientSearch:
             dc=mocked_datacommons_client,
             search_scope=SearchScope.BASE_AND_CUSTOM,
             base_index="medium_ft",
-            custom_index="user_all_minilm_mem"
+            custom_index="user_all_minilm_mem",
         )
-        
+
         mock_response = Mock()
         mock_response.json.return_value = {
             "queryResults": {
-                "test query": {
-                    "SV": ["var1", "var2"],
-                    "CosineScore": [0.8, 0.6]
-                }
+                "test query": {"SV": ["var1", "var2"], "CosineScore": [0.8, 0.6]}
             }
         }
         mock_response.raise_for_status.return_value = None
@@ -180,26 +189,21 @@ class TestDCClientSearch:
         assert "idx=user_all_minilm_mem,medium_ft" in call_args[0][0]
         assert result["test query"] == [
             {"SV": "var1", "CosineScore": 0.8},
-            {"SV": "var2", "CosineScore": 0.6}
+            {"SV": "var2", "CosineScore": 0.6},
         ]
 
     @pytest.mark.asyncio
-    @patch('datacommons_mcp.clients.requests.post')
+    @patch("datacommons_mcp.clients.requests.post")
     async def test_search_svs_skip_topics(self, mock_post, mocked_datacommons_client):
         """
         Test that search_svs respects the skip_topics parameter.
         """
         # Arrange: Create client and mock response
         client_under_test = DCClient(dc=mocked_datacommons_client)
-        
+
         mock_response = Mock()
         mock_response.json.return_value = {
-            "queryResults": {
-                "test query": {
-                    "SV": ["var1"],
-                    "CosineScore": [0.8]
-                }
-            }
+            "queryResults": {"test query": {"SV": ["var1"], "CosineScore": [0.8]}}
         }
         mock_response.raise_for_status.return_value = None
         mock_post.return_value = mock_response
@@ -212,20 +216,22 @@ class TestDCClientSearch:
         assert "skip_topics=true" in call_args[0][0]
 
     @pytest.mark.asyncio
-    @patch('datacommons_mcp.clients.requests.post')
-    async def test_search_svs_max_results_limit(self, mock_post, mocked_datacommons_client):
+    @patch("datacommons_mcp.clients.requests.post")
+    async def test_search_svs_max_results_limit(
+        self, mock_post, mocked_datacommons_client
+    ):
         """
         Test that search_svs respects the max_results parameter.
         """
         # Arrange: Create client and mock response with more results than limit
         client_under_test = DCClient(dc=mocked_datacommons_client)
-        
+
         mock_response = Mock()
         mock_response.json.return_value = {
             "queryResults": {
                 "test query": {
                     "SV": ["var1", "var2", "var3", "var4", "var5"],
-                    "CosineScore": [0.9, 0.8, 0.7, 0.6, 0.5]
+                    "CosineScore": [0.9, 0.8, 0.7, 0.6, 0.5],
                 }
             }
         }
@@ -240,7 +246,7 @@ class TestDCClientSearch:
         assert result["test query"] == [
             {"SV": "var1", "CosineScore": 0.9},
             {"SV": "var2", "CosineScore": 0.8},
-            {"SV": "var3", "CosineScore": 0.7}
+            {"SV": "var3", "CosineScore": 0.7},
         ]
 
 
@@ -281,20 +287,19 @@ class TestDCClientObservations:
                     }
                 }
             },
-            "facets": {
-                "source1": {"importName": "test_source"}
-            },
+            "facets": {"source1": {"importName": "test_source"}},
         }
         mock_api_response = ObservationApiResponse.model_validate(api_response_data)
         mocked_datacommons_client.observation.fetch.return_value = mock_api_response
 
         # Mock fetch_entity_names to return place names
-        client_under_test.fetch_entity_names = Mock(return_value={"place1": "Test Place"})
+        client_under_test.fetch_entity_names = Mock(
+            return_value={"place1": "Test Place"}
+        )
 
         # Act: Call the method on our wrapper client
         result = await client_under_test.fetch_obs(request)
 
-        
         expected_response = ObservationToolResponse(
             place_data={
                 "place1": PlaceData(
@@ -307,24 +312,21 @@ class TestDCClientObservations:
                                 source_id="source1",
                                 earliest_date="2023-01-01",
                                 latest_date="2023-01-01",
-                                total_observations=1
+                                total_observations=1,
                             ),
                             observations=[{"date": "2023-01-01", "value": 100}],
-                            alternative_sources=[]
+                            alternative_sources=[],
                         )
-                    }
+                    },
                 )
             },
             source_info={
-                "source1": Source(
-                    importName="test_source",
-                    source_id="source1"
-                )
-            }
+                "source1": Source(importName="test_source", source_id="source1")
+            },
         )
-        
+
         assert result == expected_response
-        
+
         # Verify that the API was called correctly
         mocked_datacommons_client.observation.fetch.assert_called_once_with(
             variable_dcids="var1",
@@ -332,7 +334,7 @@ class TestDCClientObservations:
             date=ObservationPeriod.LATEST,
             filter_facet_ids=None,
         )
-        
+
         # Verify that place metadata was added
         client_under_test.fetch_entity_names.assert_called_once_with(["place1"])
 
@@ -380,27 +382,26 @@ class TestDCClientObservations:
                                     ],
                                 }
                             ]
-                        }
+                        },
                     }
                 }
             },
-            "facets": {
-                "source1": {"importName": "test_source"}
-            },
+            "facets": {"source1": {"importName": "test_source"}},
         }
         mock_api_response = ObservationApiResponse.model_validate(api_response_data)
         mocked_datacommons_client.observation.fetch_observations_by_entity_type.return_value = mock_api_response
 
         # Mock fetch_entity_names to return place names
-        client_under_test.fetch_entity_names = Mock(return_value={
-            "child_place1": "Child Place 1",
-            "child_place2": "Child Place 2"
-        })
+        client_under_test.fetch_entity_names = Mock(
+            return_value={
+                "child_place1": "Child Place 1",
+                "child_place2": "Child Place 2",
+            }
+        )
 
         # Act: Call the method on our wrapper client
         result = await client_under_test.fetch_obs(request)
 
-        
         expected_response = ObservationToolResponse(
             place_data={
                 "child_place1": PlaceData(
@@ -413,12 +414,12 @@ class TestDCClientObservations:
                                 source_id="source1",
                                 earliest_date="2023-01-01",
                                 latest_date="2023-01-01",
-                                total_observations=1
+                                total_observations=1,
                             ),
                             observations=[{"date": "2023-01-01", "value": 50}],
-                            alternative_sources=[]
+                            alternative_sources=[],
                         )
-                    }
+                    },
                 ),
                 "child_place2": PlaceData(
                     place_dcid="child_place2",
@@ -430,24 +431,21 @@ class TestDCClientObservations:
                                 source_id="source1",
                                 earliest_date="2023-01-01",
                                 latest_date="2023-01-01",
-                                total_observations=1
+                                total_observations=1,
                             ),
                             observations=[{"date": "2023-01-01", "value": 75}],
-                            alternative_sources=[]
+                            alternative_sources=[],
                         )
-                    }
-                )
+                    },
+                ),
             },
             source_info={
-                "source1": Source(
-                    importName="test_source",
-                    source_id="source1"
-                )
-            }
+                "source1": Source(importName="test_source", source_id="source1")
+            },
         )
-        
+
         assert result == expected_response
-        
+
         # Verify that the API was called correctly
         mocked_datacommons_client.observation.fetch_observations_by_entity_type.assert_called_once_with(
             variable_dcids="var1",
@@ -456,9 +454,11 @@ class TestDCClientObservations:
             date=ObservationPeriod.LATEST,
             filter_facet_ids=None,
         )
-        
+
         # Verify that place metadata was added for both child places
-        client_under_test.fetch_entity_names.assert_called_once_with(["child_place1", "child_place2"])
+        client_under_test.fetch_entity_names.assert_called_once_with(
+            ["child_place1", "child_place2"]
+        )
 
 
 class TestDCClientFetchTopicsAndVariables:
@@ -469,7 +469,7 @@ class TestDCClientFetchTopicsAndVariables:
         """Test basic functionality without place filtering."""
         # Arrange: Create client and mock search results
         client_under_test = DCClient(dc=mocked_datacommons_client)
-        
+
         # Mock search_svs to return topics and variables
         mock_search_results = {
             "test query": [
@@ -479,10 +479,10 @@ class TestDCClientFetchTopicsAndVariables:
                 {"SV": "dc/variable/Count_Household", "CosineScore": 0.6},
             ]
         }
-        
+
         # Mock the search_svs method
         client_under_test.search_svs = AsyncMock(return_value=mock_search_results)
-        
+
         # Mock topic store
         client_under_test.topic_store = Mock()
         client_under_test.topic_store.get_name.side_effect = lambda dcid: {
@@ -491,17 +491,15 @@ class TestDCClientFetchTopicsAndVariables:
             "dc/variable/Count_Person": "Count of Persons",
             "dc/variable/Count_Household": "Count of Households",
         }.get(dcid, dcid)
-        
+
         # Mock topic data
         client_under_test.topic_store.topics_by_dcid = {
             "dc/topic/Health": Mock(
-                member_topics=[],
-                variables=["dc/variable/Count_Person"]
+                member_topics=[], variables=["dc/variable/Count_Person"]
             ),
             "dc/topic/Economy": Mock(
-                member_topics=[],
-                variables=["dc/variable/Count_Household"]
-            )
+                member_topics=[], variables=["dc/variable/Count_Household"]
+            ),
         }
 
         # Act: Call the method
@@ -511,30 +509,32 @@ class TestDCClientFetchTopicsAndVariables:
         assert "topics" in result
         assert "variables" in result
         assert "lookups" in result
-        
+
         # Verify topics
         assert len(result["topics"]) == 2
         topic_dcids = [topic["dcid"] for topic in result["topics"]]
         assert "dc/topic/Health" in topic_dcids
         assert "dc/topic/Economy" in topic_dcids
-        
+
         # Verify variables
         assert len(result["variables"]) == 2
         variable_dcids = [var["dcid"] for var in result["variables"]]
         assert "dc/variable/Count_Person" in variable_dcids
         assert "dc/variable/Count_Household" in variable_dcids
-        
+
         # Verify lookups
         assert len(result["lookups"]) == 4
         assert result["lookups"]["dc/topic/Health"] == "Health"
         assert result["lookups"]["dc/variable/Count_Person"] == "Count of Persons"
 
     @pytest.mark.asyncio
-    async def test_fetch_topics_and_variables_with_places(self, mocked_datacommons_client):
+    async def test_fetch_topics_and_variables_with_places(
+        self, mocked_datacommons_client
+    ):
         """Test functionality with place filtering."""
         # Arrange: Create client and mock search results
         client_under_test = DCClient(dc=mocked_datacommons_client)
-        
+
         # Mock search_svs to return topics and variables
         mock_search_results = {
             "test query": [
@@ -542,25 +542,25 @@ class TestDCClientFetchTopicsAndVariables:
                 {"SV": "dc/variable/Count_Person", "CosineScore": 0.7},
             ]
         }
-        
+
         # Mock the search_svs method
         client_under_test.search_svs = AsyncMock(return_value=mock_search_results)
-        
+
         # Mock topic store
         client_under_test.topic_store = Mock()
         client_under_test.topic_store.get_name.side_effect = lambda dcid: {
             "dc/topic/Health": "Health",
             "dc/variable/Count_Person": "Count of Persons",
         }.get(dcid, dcid)
-        
+
         # Mock topic data
         client_under_test.topic_store.topics_by_dcid = {
             "dc/topic/Health": Mock(
                 member_topics=[],
-                variables=["dc/variable/Count_Person", "dc/variable/Count_Household"]
+                variables=["dc/variable/Count_Person", "dc/variable/Count_Household"],
             )
         }
-        
+
         # Mock variable cache to simulate data existence
         client_under_test.variable_cache = Mock()
         client_under_test.variable_cache.get.side_effect = lambda place_dcid: {
@@ -590,7 +590,11 @@ class TestDCClientFetchTopicsAndVariables:
         }.get(place_dcid, set())
 
         # Act: Filter variables
-        variables = ["dc/variable/Count_Person", "dc/variable/Count_Household", "dc/variable/Count_Business"]
+        variables = [
+            "dc/variable/Count_Person",
+            "dc/variable/Count_Household",
+            "dc/variable/Count_Business",
+        ]
         result = client_under_test._filter_variables_by_existence(
             variables, ["geoId/06", "geoId/36"]
         )
@@ -601,9 +605,11 @@ class TestDCClientFetchTopicsAndVariables:
         assert "dc/variable/Count_Person" in var_dcids
         assert "dc/variable/Count_Household" in var_dcids
         assert "dc/variable/Count_Business" not in var_dcids
-        
+
         # Verify places_with_data
-        count_person = next(var for var in result if var["dcid"] == "dc/variable/Count_Person")
+        count_person = next(
+            var for var in result if var["dcid"] == "dc/variable/Count_Person"
+        )
         assert count_person["places_with_data"] == ["geoId/06", "geoId/36"]
 
     def test_filter_topics_by_existence(self, mocked_datacommons_client):
@@ -613,11 +619,10 @@ class TestDCClientFetchTopicsAndVariables:
         client_under_test.topic_store = Mock()
         client_under_test.topic_store.topics_by_dcid = {
             "dc/topic/Health": Mock(
-                member_topics=[],
-                variables=["dc/variable/Count_Person"]
+                member_topics=[], variables=["dc/variable/Count_Person"]
             )
         }
-        
+
         # Mock variable cache
         client_under_test.variable_cache = Mock()
         client_under_test.variable_cache.get.side_effect = lambda place_dcid: {
@@ -644,10 +649,10 @@ class TestDCClientFetchTopicsAndVariables:
         client_under_test.topic_store.topics_by_dcid = {
             "dc/topic/Health": Mock(
                 member_topics=["dc/topic/HealthCare"],
-                variables=["dc/variable/Count_Person", "dc/variable/Count_Household"]
+                variables=["dc/variable/Count_Person", "dc/variable/Count_Household"],
             )
         }
-        
+
         # Mock variable cache
         client_under_test.variable_cache = Mock()
         client_under_test.variable_cache.get.side_effect = lambda place_dcid: {
@@ -668,24 +673,29 @@ class TestDCClientFetchTopicsAndVariables:
         assert health_topic["member_topics"] == []
 
     @pytest.mark.asyncio
-    async def test_search_entities_filters_invalid_topics(self, mocked_datacommons_client):
+    async def test_search_entities_filters_invalid_topics(
+        self, mocked_datacommons_client
+    ):
         """Test that _search_entities filters out topics that don't exist in the topic store."""
         # Arrange: Create client and mock search results
         client_under_test = DCClient(dc=mocked_datacommons_client)
-        
+
         # Mock search_svs to return topics (some valid, some invalid) and variables
         mock_search_results = {
             "test query": [
                 {"SV": "dc/topic/Health", "CosineScore": 0.9},  # Valid topic
-                {"SV": "dc/topic/InvalidTopic", "CosineScore": 0.8},  # Invalid topic (not in store)
+                {
+                    "SV": "dc/topic/InvalidTopic",
+                    "CosineScore": 0.8,
+                },  # Invalid topic (not in store)
                 {"SV": "dc/topic/Economy", "CosineScore": 0.7},  # Valid topic
                 {"SV": "dc/variable/Count_Person", "CosineScore": 0.6},  # Variable
             ]
         }
-        
+
         # Mock the search_svs method
         client_under_test.search_svs = AsyncMock(return_value=mock_search_results)
-        
+
         # Mock topic store to only contain some topics
         client_under_test.topic_store = Mock()
         client_under_test.topic_store.topics_by_dcid = {
@@ -700,13 +710,15 @@ class TestDCClientFetchTopicsAndVariables:
         # Assert: Verify that only valid topics are returned
         assert "topics" in result
         assert "variables" in result
-        
+
         # Verify topics - should only include topics that exist in the topic store
         assert len(result["topics"]) == 2
         assert "dc/topic/Health" in result["topics"]
         assert "dc/topic/Economy" in result["topics"]
-        assert "dc/topic/InvalidTopic" not in result["topics"]  # Invalid topic should be filtered out
-        
+        assert (
+            "dc/topic/InvalidTopic" not in result["topics"]
+        )  # Invalid topic should be filtered out
+
         # Verify variables - should include all variables
         assert len(result["variables"]) == 1
         assert "dc/variable/Count_Person" in result["variables"]
@@ -716,7 +728,7 @@ class TestDCClientFetchTopicsAndVariables:
         """Test that _search_entities handles case when topic store is None."""
         # Arrange: Create client and mock search results
         client_under_test = DCClient(dc=mocked_datacommons_client)
-        
+
         # Mock search_svs to return topics and variables
         mock_search_results = {
             "test query": [
@@ -724,10 +736,10 @@ class TestDCClientFetchTopicsAndVariables:
                 {"SV": "dc/variable/Count_Person", "CosineScore": 0.6},
             ]
         }
-        
+
         # Mock the search_svs method
         client_under_test.search_svs = AsyncMock(return_value=mock_search_results)
-        
+
         # Set topic store to None
         client_under_test.topic_store = None
 
@@ -737,19 +749,21 @@ class TestDCClientFetchTopicsAndVariables:
         # Assert: Verify that no topics are returned when topic store is None
         assert "topics" in result
         assert "variables" in result
-        
+
         # Verify topics - should be empty when topic store is None
         assert len(result["topics"]) == 0
-        
+
         # Verify variables - should include all variables
         assert len(result["variables"]) == 1
         assert "dc/variable/Count_Person" in result["variables"]
 
     @pytest.mark.asyncio
-    async def test_search_entities_with_per_search_limit(self, mocked_datacommons_client):
+    async def test_search_entities_with_per_search_limit(
+        self, mocked_datacommons_client
+    ):
         """Test _search_entities with per_search_limit parameter."""
         client_under_test = DCClient(dc=mocked_datacommons_client)
-        
+
         # Mock search_svs to return results
         mock_search_results = {
             "test query": [
@@ -822,9 +836,7 @@ class TestDCClientIntegrateObservationResponse:
     def test_integrate_observation_initial_data(self, mock_api_response):
         """Test that _integrate_observation_response correctly processes initial data."""
         response = ObservationToolResponse()
-        DCClient._integrate_observation_response(
-            response, mock_api_response
-        )
+        DCClient._integrate_observation_response(response, mock_api_response)
 
         assert "place1" in response.place_data
         place_data = response.place_data["place1"]
@@ -850,9 +862,7 @@ class TestDCClientIntegrateObservationResponse:
         )
         response.place_data["place1"] = Mock(variable_series={"var1": initial_series})
 
-        DCClient._integrate_observation_response(
-            response, mock_api_response
-        )
+        DCClient._integrate_observation_response(response, mock_api_response)
 
         # Check that the new sources were appended
         final_series = response.place_data["place1"].variable_series["var1"]
@@ -879,13 +889,12 @@ class TestCreateDCClient:
 
     @patch("datacommons_mcp.clients.DataCommonsClient")
     @patch("datacommons_mcp.clients.read_topic_cache")
-    def test_create_dc_client_base_dc(self, mock_read_cache: Mock, mock_dc_client: Mock):
+    def test_create_dc_client_base_dc(
+        self, mock_read_cache: Mock, mock_dc_client: Mock
+    ):
         """Test base DC creation with defaults."""
         # Arrange
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_api_key',
-            'DC_TYPE': 'base'
-        }):
+        with patch.dict(os.environ, {"DC_API_KEY": "test_api_key", "DC_TYPE": "base"}):
             settings = BaseDCSettings()
             mock_dc_instance = Mock()
             mock_dc_client.return_value = mock_dc_instance
@@ -904,14 +913,19 @@ class TestCreateDCClient:
 
     @patch("datacommons_mcp.clients.DataCommonsClient")
     @patch("datacommons_mcp.clients.create_topic_store")
-    def test_create_dc_client_custom_dc(self, mock_create_store: Mock, mock_dc_client: Mock):
+    def test_create_dc_client_custom_dc(
+        self, mock_create_store: Mock, mock_dc_client: Mock
+    ):
         """Test custom DC creation with defaults."""
         # Arrange
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_api_key',
-            'DC_TYPE': 'custom',
-            'CUSTOM_DC_URL': 'https://staging-datacommons-web-service-650536812276.northamerica-northeast1.run.app'
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "DC_API_KEY": "test_api_key",
+                "DC_TYPE": "custom",
+                "CUSTOM_DC_URL": "https://staging-datacommons-web-service-650536812276.northamerica-northeast1.run.app",
+            },
+        ):
             settings = CustomDCSettings()
             mock_dc_instance = Mock()
             mock_dc_client.return_value = mock_dc_instance
@@ -927,7 +941,10 @@ class TestCreateDCClient:
             assert result.search_scope == SearchScope.BASE_AND_CUSTOM
             assert result.base_index == "medium_ft"
             assert result.custom_index == "user_all_minilm_mem"
-            assert result.sv_search_base_url == "https://staging-datacommons-web-service-650536812276.northamerica-northeast1.run.app"
+            assert (
+                result.sv_search_base_url
+                == "https://staging-datacommons-web-service-650536812276.northamerica-northeast1.run.app"
+            )
             # Should have called DataCommonsClient with computed api_base_url
             expected_api_url = "https://staging-datacommons-web-service-650536812276.northamerica-northeast1.run.app/core/api/v2/"
             mock_dc_client.assert_called_with(url=expected_api_url)
@@ -936,11 +953,14 @@ class TestCreateDCClient:
     def test_create_dc_client_url_computation(self, mock_dc_client):
         """Test URL computation for custom DC."""
         # Arrange
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_api_key',
-            'DC_TYPE': 'custom',
-            'CUSTOM_DC_URL': 'https://example.com'  # No trailing slash
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "DC_API_KEY": "test_api_key",
+                "DC_TYPE": "custom",
+                "CUSTOM_DC_URL": "https://example.com",  # No trailing slash
+            },
+        ):
             settings = CustomDCSettings()
             mock_dc_instance = Mock()
             mock_dc_client.return_value = mock_dc_instance

--- a/packages/datacommons-mcp/tests/test_services.py
+++ b/packages/datacommons-mcp/tests/test_services.py
@@ -17,7 +17,11 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 from datacommons_mcp.data_models.observations import ObservationPeriod
 from datacommons_mcp.exceptions import NoDataFoundError
-from datacommons_mcp.services import _build_observation_request, get_observations, search_indicators
+from datacommons_mcp.services import (
+    _build_observation_request,
+    get_observations,
+    search_indicators,
+)
 
 
 @pytest.mark.asyncio
@@ -105,15 +109,15 @@ class TestGetObservations:
             client=mock_client,
             variable_dcid="Count_Person",
             place_name="USA",
-            period="latest"
+            period="latest",
         )
 
         # Verify the result
         assert result == mock_response
-        
+
         # Verify search_places was called
         mock_client.search_places.assert_awaited_once_with(["USA"])
-        
+
         # Verify fetch_obs was called with the correct request
         mock_client.fetch_obs.assert_awaited_once()
         call_args = mock_client.fetch_obs.call_args[0][0]
@@ -132,24 +136,21 @@ class TestGetObservations:
             client=mock_client,
             variable_dcid="Count_Person",
             place_dcid="country/USA",
-            period="latest"
+            period="latest",
         )
 
         # Verify the result
         assert result == mock_response
-        
+
         # Verify search_places was NOT called (since we provided DCID)
         mock_client.search_places.assert_not_called()
-        
+
         # Verify fetch_obs was called with the correct request
         mock_client.fetch_obs.assert_awaited_once()
         call_args = mock_client.fetch_obs.call_args[0][0]
         assert call_args.variable_dcid == "Count_Person"
         assert call_args.place_dcid == "country/USA"
         assert call_args.observation_period == ObservationPeriod.LATEST
-
-
-
 
 
 @pytest.mark.asyncio
@@ -160,19 +161,19 @@ class TestSearchIndicators:
     async def test_search_indicators_browse_mode_basic(self):
         """Test basic search in browse mode without place filtering."""
         mock_client = Mock()
-        mock_client.fetch_topics_and_variables = AsyncMock(return_value={
-            "topics": [{"dcid": "topic/health"}],
-            "variables": [{"dcid": "Count_Person"}],
-            "lookups": {"topic/health": "Health", "Count_Person": "Population"}
-        })
-        mock_client.fetch_entity_names = Mock(return_value={
-            "topic/health": "Health", "Count_Person": "Population"
-        })
+        mock_client.fetch_topics_and_variables = AsyncMock(
+            return_value={
+                "topics": [{"dcid": "topic/health"}],
+                "variables": [{"dcid": "Count_Person"}],
+                "lookups": {"topic/health": "Health", "Count_Person": "Population"},
+            }
+        )
+        mock_client.fetch_entity_names = Mock(
+            return_value={"topic/health": "Health", "Count_Person": "Population"}
+        )
 
         result = await search_indicators(
-            client=mock_client,
-            query="health",
-            mode="browse"
+            client=mock_client, query="health", mode="browse"
         )
 
         assert result.topics is not None
@@ -186,20 +187,29 @@ class TestSearchIndicators:
         """Test search in browse mode with place filtering."""
         mock_client = Mock()
         mock_client.search_places = AsyncMock(return_value={"France": "country/FRA"})
-        mock_client.fetch_topics_and_variables = AsyncMock(return_value={
-            "topics": [{"dcid": "topic/trade"}],
-            "variables": [{"dcid": "TradeExports_FRA"}],
-            "lookups": {"topic/trade": "Trade", "TradeExports_FRA": "Exports to France"}
-        })
-        mock_client.fetch_entity_names = Mock(return_value={
-            "topic/trade": "Trade", "TradeExports_FRA": "Exports to France", "country/FRA": "France"
-        })
+        mock_client.fetch_topics_and_variables = AsyncMock(
+            return_value={
+                "topics": [{"dcid": "topic/trade"}],
+                "variables": [{"dcid": "TradeExports_FRA"}],
+                "lookups": {
+                    "topic/trade": "Trade",
+                    "TradeExports_FRA": "Exports to France",
+                },
+            }
+        )
+        mock_client.fetch_entity_names = Mock(
+            return_value={
+                "topic/trade": "Trade",
+                "TradeExports_FRA": "Exports to France",
+                "country/FRA": "France",
+            }
+        )
 
         result = await search_indicators(
             client=mock_client,
             query="trade exports",
             mode="browse",
-            place1_name="France"
+            place1_name="France",
         )
 
         assert result.topics is not None
@@ -224,44 +234,47 @@ class TestSearchIndicators:
         """Test that results from multiple searches are properly merged in browse mode."""
         mock_client = Mock()
         mock_client.search_places = AsyncMock(return_value={"France": "country/FRA"})
-        mock_client.fetch_topics_and_variables = AsyncMock(side_effect=[
-            {
-                "topics": [{"dcid": "topic/trade"}],
-                "variables": [{"dcid": "TradeExports_FRA"}],
-                "lookups": {
-                    "topic/trade": "Trade", 
-                    "TradeExports_FRA": "Exports to France"
-                }
-            },
-            {
-                "topics": [{"dcid": "topic/trade"}],  # Duplicate topic
-                "variables": [
-                    {"dcid": "TradeImports_FRA"},  # New variable
-                    {"dcid": "TradeExports_FRA"}   # Duplicate variable
-                ],
-                "lookups": {
-                    "topic/trade": "Trade", 
-                    "TradeImports_FRA": "Imports from France", 
-                    "TradeExports_FRA": "Exports to France"
-                }
+        mock_client.fetch_topics_and_variables = AsyncMock(
+            side_effect=[
+                {
+                    "topics": [{"dcid": "topic/trade"}],
+                    "variables": [{"dcid": "TradeExports_FRA"}],
+                    "lookups": {
+                        "topic/trade": "Trade",
+                        "TradeExports_FRA": "Exports to France",
+                    },
+                },
+                {
+                    "topics": [{"dcid": "topic/trade"}],  # Duplicate topic
+                    "variables": [
+                        {"dcid": "TradeImports_FRA"},  # New variable
+                        {"dcid": "TradeExports_FRA"},  # Duplicate variable
+                    ],
+                    "lookups": {
+                        "topic/trade": "Trade",
+                        "TradeImports_FRA": "Imports from France",
+                        "TradeExports_FRA": "Exports to France",
+                    },
+                },
+            ]
+        )
+        mock_client.fetch_entity_names = Mock(
+            return_value={
+                "topic/trade": "Trade",
+                "TradeExports_FRA": "Exports to France",
+                "TradeImports_FRA": "Imports from France",
             }
-        ])
-        mock_client.fetch_entity_names = Mock(return_value={
-            "topic/trade": "Trade",
-            "TradeExports_FRA": "Exports to France",
-            "TradeImports_FRA": "Imports from France"
-        })
+        )
 
         result = await search_indicators(
-            client=mock_client,
-            query="trade",
-            mode="browse",
-            place1_name="France"
+            client=mock_client, query="trade", mode="browse", place1_name="France"
         )
 
         # Should have deduplicated topics and variables
         assert len(result.topics) == 1  # Deduplicated
-        assert len(result.variables) == 2  # Both unique variables included (duplicate removed)
+        assert (
+            len(result.variables) == 2
+        )  # Both unique variables included (duplicate removed)
         assert "TradeExports_FRA" in [v.dcid for v in result.variables]
         assert "TradeImports_FRA" in [v.dcid for v in result.variables]
 
@@ -269,20 +282,19 @@ class TestSearchIndicators:
     async def test_search_indicators_browse_mode_with_custom_per_search_limit(self):
         """Test search in browse mode with custom per_search_limit parameter."""
         mock_client = Mock()
-        mock_client.fetch_topics_and_variables = AsyncMock(return_value={
-            "topics": [{"dcid": "topic/health"}],
-            "variables": [{"dcid": "Count_Person"}],
-            "lookups": {"topic/health": "Health", "Count_Person": "Population"}
-        })
-        mock_client.fetch_entity_names = Mock(return_value={
-            "topic/health": "Health", "Count_Person": "Population"
-        })
+        mock_client.fetch_topics_and_variables = AsyncMock(
+            return_value={
+                "topics": [{"dcid": "topic/health"}],
+                "variables": [{"dcid": "Count_Person"}],
+                "lookups": {"topic/health": "Health", "Count_Person": "Population"},
+            }
+        )
+        mock_client.fetch_entity_names = Mock(
+            return_value={"topic/health": "Health", "Count_Person": "Population"}
+        )
 
         result = await search_indicators(
-            client=mock_client,
-            query="health",
-            mode="browse",
-            per_search_limit=5
+            client=mock_client, query="health", mode="browse", per_search_limit=5
         )
 
         assert result.topics is not None
@@ -300,38 +312,40 @@ class TestSearchIndicators:
         mock_client = Mock()
 
         # Test invalid per_search_limit values
-        with pytest.raises(ValueError, match="per_search_limit must be between 1 and 100"):
+        with pytest.raises(
+            ValueError, match="per_search_limit must be between 1 and 100"
+        ):
             await search_indicators(
-                client=mock_client,
-                query="health",
-                mode="browse",
-                per_search_limit=0
+                client=mock_client, query="health", mode="browse", per_search_limit=0
             )
 
-        with pytest.raises(ValueError, match="per_search_limit must be between 1 and 100"):
+        with pytest.raises(
+            ValueError, match="per_search_limit must be between 1 and 100"
+        ):
             await search_indicators(
-                client=mock_client,
-                query="health",
-                mode="browse",
-                per_search_limit=101
+                client=mock_client, query="health", mode="browse", per_search_limit=101
             )
 
         # Test valid per_search_limit values
-        mock_client.fetch_topics_and_variables = AsyncMock(return_value={
-            "topics": [], "variables": [], "lookups": {}
-        })
+        mock_client.fetch_topics_and_variables = AsyncMock(
+            return_value={"topics": [], "variables": [], "lookups": {}}
+        )
 
         # Should not raise for valid values
-        await search_indicators(client=mock_client, query="health", mode="browse", per_search_limit=1)
-        await search_indicators(client=mock_client, query="health", mode="browse", per_search_limit=100)
+        await search_indicators(
+            client=mock_client, query="health", mode="browse", per_search_limit=1
+        )
+        await search_indicators(
+            client=mock_client, query="health", mode="browse", per_search_limit=100
+        )
 
     @pytest.mark.asyncio
     async def test_search_indicators_browse_mode_default_per_search_limit(self):
         """Test that default per_search_limit=10 is used when not specified in browse mode."""
         mock_client = Mock()
-        mock_client.fetch_topics_and_variables = AsyncMock(return_value={
-            "topics": [], "variables": [], "lookups": {}
-        })
+        mock_client.fetch_topics_and_variables = AsyncMock(
+            return_value={"topics": [], "variables": [], "lookups": {}}
+        )
 
         await search_indicators(client=mock_client, query="health", mode="browse")
 
@@ -344,19 +358,18 @@ class TestSearchIndicators:
     async def test_search_indicators_browse_mode_default_mode(self):
         """Test that browse mode is the default when mode is not specified."""
         mock_client = Mock()
-        mock_client.fetch_topics_and_variables = AsyncMock(return_value={
-            "topics": [{"dcid": "topic/health"}],
-            "variables": [{"dcid": "Count_Person"}],
-            "lookups": {"topic/health": "Health", "Count_Person": "Population"}
-        })
-        mock_client.fetch_entity_names = Mock(return_value={
-            "topic/health": "Health", "Count_Person": "Population"
-        })
-
-        result = await search_indicators(
-            client=mock_client,
-            query="health"
+        mock_client.fetch_topics_and_variables = AsyncMock(
+            return_value={
+                "topics": [{"dcid": "topic/health"}],
+                "variables": [{"dcid": "Count_Person"}],
+                "lookups": {"topic/health": "Health", "Count_Person": "Population"},
+            }
         )
+        mock_client.fetch_entity_names = Mock(
+            return_value={"topic/health": "Health", "Count_Person": "Population"}
+        )
+
+        result = await search_indicators(client=mock_client, query="health")
 
         assert result.topics is not None
         assert result.variables is not None
@@ -370,22 +383,24 @@ class TestSearchIndicators:
         mock_client = Mock()
 
         # Test invalid mode values
-        with pytest.raises(ValueError, match="mode must be either 'browse' or 'lookup'"):
+        with pytest.raises(
+            ValueError, match="mode must be either 'browse' or 'lookup'"
+        ):
             await search_indicators(
-                client=mock_client,
-                query="health",
-                mode="invalid_mode"
+                client=mock_client, query="health", mode="invalid_mode"
             )
 
         # Test valid mode values
-        mock_client.fetch_topics_and_variables = AsyncMock(return_value={
-            "topics": [], "variables": [], "lookups": {}
-        })
+        mock_client.fetch_topics_and_variables = AsyncMock(
+            return_value={"topics": [], "variables": [], "lookups": {}}
+        )
 
         # Should not raise for valid values
         await search_indicators(client=mock_client, query="health", mode="browse")
         await search_indicators(client=mock_client, query="health", mode="lookup")
-        await search_indicators(client=mock_client, query="health", mode=None)  # None should default to browse
+        await search_indicators(
+            client=mock_client, query="health", mode=None
+        )  # None should default to browse
 
     # Phase 2: Lookup Mode Tests
     @pytest.mark.asyncio
@@ -393,18 +408,19 @@ class TestSearchIndicators:
         """Test basic search in lookup mode with a single place."""
         mock_client = Mock()
         mock_client.search_places = AsyncMock(return_value={"USA": "country/USA"})
-        mock_client.fetch_topic_variables = AsyncMock(return_value={
-            "topic_variable_ids": ["Count_Person", "Count_Household"]
-        })
-        mock_client.fetch_entity_names = Mock(return_value={
-            "Count_Person": "Population", "Count_Household": "Households", "country/USA": "USA"
-        })
+        mock_client.fetch_topic_variables = AsyncMock(
+            return_value={"topic_variable_ids": ["Count_Person", "Count_Household"]}
+        )
+        mock_client.fetch_entity_names = Mock(
+            return_value={
+                "Count_Person": "Population",
+                "Count_Household": "Households",
+                "country/USA": "USA",
+            }
+        )
 
         result = await search_indicators(
-            client=mock_client,
-            query="health",
-            mode="lookup",
-            place1_name="USA"
+            client=mock_client, query="health", mode="lookup", place1_name="USA"
         )
 
         assert result.topics is None  # No topics in lookup mode
@@ -421,20 +437,24 @@ class TestSearchIndicators:
         """Test search in lookup mode with place filtering."""
         mock_client = Mock()
         mock_client.search_places = AsyncMock(return_value={"France": "country/FRA"})
-        mock_client.fetch_topic_variables = AsyncMock(return_value={
-            "topic_variable_ids": ["TradeExports_FRA", "TradeImports_FRA"]
-        })
-        mock_client.fetch_entity_names = Mock(return_value={
-            "TradeExports_FRA": "Exports to France", 
-            "TradeImports_FRA": "Imports from France",
-            "country/FRA": "France"
-        })
+        mock_client.fetch_topic_variables = AsyncMock(
+            return_value={
+                "topic_variable_ids": ["TradeExports_FRA", "TradeImports_FRA"]
+            }
+        )
+        mock_client.fetch_entity_names = Mock(
+            return_value={
+                "TradeExports_FRA": "Exports to France",
+                "TradeImports_FRA": "Imports from France",
+                "country/FRA": "France",
+            }
+        )
 
         result = await search_indicators(
             client=mock_client,
             query="trade exports",
             mode="lookup",
-            place1_name="France"
+            place1_name="France",
         )
 
         assert result.topics is None  # No topics in lookup mode
@@ -454,29 +474,39 @@ class TestSearchIndicators:
     async def test_search_indicators_lookup_mode_merge_results(self):
         """Test that results from multiple searches are properly merged in lookup mode."""
         mock_client = Mock()
-        mock_client.search_places = AsyncMock(return_value={"France": "country/FRA", "Germany": "country/DEU"})
-        mock_client.fetch_topic_variables = AsyncMock(side_effect=[
-            {"topic_variable_ids": ["TradeExports_FRA"]},  # France results
-            {"topic_variable_ids": ["TradeExports_DEU", "TradeExports_FRA"]}  # Germany results (with duplicate)
-        ])
-        mock_client.fetch_entity_names = Mock(return_value={
-            "TradeExports_FRA": "Exports to France",
-            "TradeExports_DEU": "Exports to Germany",
-            "country/FRA": "France",
-            "country/DEU": "Germany"
-        })
+        mock_client.search_places = AsyncMock(
+            return_value={"France": "country/FRA", "Germany": "country/DEU"}
+        )
+        mock_client.fetch_topic_variables = AsyncMock(
+            side_effect=[
+                {"topic_variable_ids": ["TradeExports_FRA"]},  # France results
+                {
+                    "topic_variable_ids": ["TradeExports_DEU", "TradeExports_FRA"]
+                },  # Germany results (with duplicate)
+            ]
+        )
+        mock_client.fetch_entity_names = Mock(
+            return_value={
+                "TradeExports_FRA": "Exports to France",
+                "TradeExports_DEU": "Exports to Germany",
+                "country/FRA": "France",
+                "country/DEU": "Germany",
+            }
+        )
 
         result = await search_indicators(
             client=mock_client,
             query="trade",
             mode="lookup",
             place1_name="France",
-            place2_name="Germany"
+            place2_name="Germany",
         )
 
         # Should have deduplicated variables
         assert result.topics is None  # No topics in lookup mode
-        assert len(result.variables) == 2  # Both unique variables included (duplicate removed)
+        assert (
+            len(result.variables) == 2
+        )  # Both unique variables included (duplicate removed)
         assert any(v.dcid == "TradeExports_FRA" for v in result.variables)
         assert any(v.dcid == "TradeExports_DEU" for v in result.variables)
 
@@ -485,22 +515,30 @@ class TestSearchIndicators:
         """Test search in lookup mode with custom per_search_limit parameter."""
         mock_client = Mock()
         mock_client.search_places = AsyncMock(return_value={"USA": "country/USA"})
-        mock_client.fetch_topic_variables = AsyncMock(return_value={
-            "topic_variable_ids": ["Count_Person", "Count_Household", "Count_Business"]
-        })
-        mock_client.fetch_entity_names = Mock(return_value={
-            "Count_Person": "Population", 
-            "Count_Household": "Households",
-            "Count_Business": "Businesses",
-            "country/USA": "USA"
-        })
+        mock_client.fetch_topic_variables = AsyncMock(
+            return_value={
+                "topic_variable_ids": [
+                    "Count_Person",
+                    "Count_Household",
+                    "Count_Business",
+                ]
+            }
+        )
+        mock_client.fetch_entity_names = Mock(
+            return_value={
+                "Count_Person": "Population",
+                "Count_Household": "Households",
+                "Count_Business": "Businesses",
+                "country/USA": "USA",
+            }
+        )
 
         result = await search_indicators(
             client=mock_client,
             query="health",
             mode="lookup",
             place1_name="USA",
-            per_search_limit=2
+            per_search_limit=2,
         )
 
         assert result.topics is None  # No topics in lookup mode
@@ -516,48 +554,56 @@ class TestSearchIndicators:
         mock_client = Mock()
 
         # Test invalid per_search_limit values
-        with pytest.raises(ValueError, match="per_search_limit must be between 1 and 100"):
+        with pytest.raises(
+            ValueError, match="per_search_limit must be between 1 and 100"
+        ):
             await search_indicators(
-                client=mock_client,
-                query="health",
-                mode="lookup",
-                per_search_limit=0
+                client=mock_client, query="health", mode="lookup", per_search_limit=0
             )
 
-        with pytest.raises(ValueError, match="per_search_limit must be between 1 and 100"):
+        with pytest.raises(
+            ValueError, match="per_search_limit must be between 1 and 100"
+        ):
             await search_indicators(
-                client=mock_client,
-                query="health",
-                mode="lookup",
-                per_search_limit=101
+                client=mock_client, query="health", mode="lookup", per_search_limit=101
             )
 
         # Test valid per_search_limit values with place (so lookup mode is actually used)
         mock_client.search_places = AsyncMock(return_value={"USA": "country/USA"})
-        mock_client.fetch_topic_variables = AsyncMock(return_value={
-            "topic_variable_ids": []
-        })
-        mock_client.fetch_entity_names = Mock(return_value={
-            "country/USA": "USA"
-        })
+        mock_client.fetch_topic_variables = AsyncMock(
+            return_value={"topic_variable_ids": []}
+        )
+        mock_client.fetch_entity_names = Mock(return_value={"country/USA": "USA"})
 
         # Should not raise for valid values
-        await search_indicators(client=mock_client, query="health", mode="lookup", place1_name="USA", per_search_limit=1)
-        await search_indicators(client=mock_client, query="health", mode="lookup", place1_name="USA", per_search_limit=100)
+        await search_indicators(
+            client=mock_client,
+            query="health",
+            mode="lookup",
+            place1_name="USA",
+            per_search_limit=1,
+        )
+        await search_indicators(
+            client=mock_client,
+            query="health",
+            mode="lookup",
+            place1_name="USA",
+            per_search_limit=100,
+        )
 
     @pytest.mark.asyncio
     async def test_search_indicators_lookup_mode_default_per_search_limit(self):
         """Test that default per_search_limit=10 is used when not specified in lookup mode."""
         mock_client = Mock()
         mock_client.search_places = AsyncMock(return_value={"USA": "country/USA"})
-        mock_client.fetch_topic_variables = AsyncMock(return_value={
-            "topic_variable_ids": []
-        })
-        mock_client.fetch_entity_names = Mock(return_value={
-            "country/USA": "USA"
-        })
+        mock_client.fetch_topic_variables = AsyncMock(
+            return_value={"topic_variable_ids": []}
+        )
+        mock_client.fetch_entity_names = Mock(return_value={"country/USA": "USA"})
 
-        await search_indicators(client=mock_client, query="health", mode="lookup", place1_name="USA")
+        await search_indicators(
+            client=mock_client, query="health", mode="lookup", place1_name="USA"
+        )
 
         # Verify default per_search_limit=10 was used (though not directly passed to fetch_topic_variables)
         # The limit is applied after fetching results
@@ -567,20 +613,22 @@ class TestSearchIndicators:
     async def test_search_indicators_automatic_fallback_to_browse_mode(self):
         """Test that lookup mode automatically falls back to browse mode when no places are provided."""
         mock_client = Mock()
-        mock_client.fetch_topics_and_variables = AsyncMock(return_value={
-            "topics": [{"dcid": "topic/health"}],
-            "variables": [{"dcid": "Count_Person"}],
-            "lookups": {"topic/health": "Health", "Count_Person": "Population"}
-        })
-        mock_client.fetch_entity_names = Mock(return_value={
-            "topic/health": "Health", "Count_Person": "Population"
-        })
+        mock_client.fetch_topics_and_variables = AsyncMock(
+            return_value={
+                "topics": [{"dcid": "topic/health"}],
+                "variables": [{"dcid": "Count_Person"}],
+                "lookups": {"topic/health": "Health", "Count_Person": "Population"},
+            }
+        )
+        mock_client.fetch_entity_names = Mock(
+            return_value={"topic/health": "Health", "Count_Person": "Population"}
+        )
 
         # Call with lookup mode but no places - should automatically fall back to browse mode
         result = await search_indicators(
             client=mock_client,
             query="health",
-            mode="lookup"  # No places provided
+            mode="lookup",  # No places provided
         )
 
         # Should return browse mode results (topics populated)

--- a/packages/datacommons-mcp/tests/test_settings.py
+++ b/packages/datacommons-mcp/tests/test_settings.py
@@ -29,36 +29,36 @@ class TestGetDCSettings:
 
     def test_get_dc_settings_base(self):
         """Test base DC settings returns BaseDCSettings."""
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'base'
-        }):
+        with patch.dict(os.environ, {"DC_API_KEY": "test_key", "DC_TYPE": "base"}):
             settings = get_dc_settings()
-            
+
             assert isinstance(settings, BaseDCSettings)
-            assert settings.dc_type == 'base'
-            assert settings.api_key == 'test_key'
-            assert settings.sv_search_base_url == 'https://datacommons.org'
-            assert settings.base_index == 'base_uae_mem'
+            assert settings.dc_type == "base"
+            assert settings.api_key == "test_key"
+            assert settings.sv_search_base_url == "https://datacommons.org"
+            assert settings.base_index == "base_uae_mem"
             assert settings.topic_cache_path is None
 
     def test_get_dc_settings_custom(self):
         """Test custom DC settings returns CustomDCSettings."""
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'custom',
-            'CUSTOM_DC_URL': 'https://test.com'
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "DC_API_KEY": "test_key",
+                "DC_TYPE": "custom",
+                "CUSTOM_DC_URL": "https://test.com",
+            },
+        ):
             settings = get_dc_settings()
-            
+
             assert isinstance(settings, CustomDCSettings)
-            assert settings.dc_type == 'custom'
-            assert settings.api_key == 'test_key'
-            assert settings.custom_dc_url == 'https://test.com'
-            assert settings.api_base_url == 'https://test.com/core/api/v2/'
+            assert settings.dc_type == "custom"
+            assert settings.api_key == "test_key"
+            assert settings.custom_dc_url == "https://test.com"
+            assert settings.api_base_url == "https://test.com/core/api/v2/"
             assert settings.search_scope == SearchScope.BASE_AND_CUSTOM
-            assert settings.base_index == 'medium_ft'
-            assert settings.custom_index == 'user_all_minilm_mem'
+            assert settings.base_index == "medium_ft"
+            assert settings.custom_index == "user_all_minilm_mem"
             assert settings.root_topic_dcids is None
 
     def test_get_dc_settings_missing_api_key(self):
@@ -69,121 +69,131 @@ class TestGetDCSettings:
 
     def test_get_dc_settings_missing_custom_dc_url(self):
         """Test missing custom DC URL for custom DC raises error."""
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'custom'
-        }):
+        with patch.dict(os.environ, {"DC_API_KEY": "test_key", "DC_TYPE": "custom"}):
             with pytest.raises(ValueError, match="CUSTOM_DC_URL"):
                 get_dc_settings()
 
     def test_get_dc_settings_invalid_type(self):
         """Test invalid DC type raises error."""
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'invalid'
-        }):
+        with patch.dict(os.environ, {"DC_API_KEY": "test_key", "DC_TYPE": "invalid"}):
             with pytest.raises(ValueError, match="Input should be 'base'"):
                 get_dc_settings()
 
     def test_get_dc_settings_defaults(self):
         """Test that defaults are applied correctly."""
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'base'
-        }):
+        with patch.dict(os.environ, {"DC_API_KEY": "test_key", "DC_TYPE": "base"}):
             settings = get_dc_settings()
-            
+
             # Base DC defaults
-            assert settings.sv_search_base_url == 'https://datacommons.org'
-            assert settings.base_index == 'base_uae_mem'
-            
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'custom',
-            'CUSTOM_DC_URL': 'https://test.com'
-        }):
+            assert settings.sv_search_base_url == "https://datacommons.org"
+            assert settings.base_index == "base_uae_mem"
+
+        with patch.dict(
+            os.environ,
+            {
+                "DC_API_KEY": "test_key",
+                "DC_TYPE": "custom",
+                "CUSTOM_DC_URL": "https://test.com",
+            },
+        ):
             settings = get_dc_settings()
-            
+
             # Custom DC defaults
             assert settings.search_scope == SearchScope.BASE_AND_CUSTOM
-            assert settings.base_index == 'medium_ft'
-            assert settings.custom_index == 'user_all_minilm_mem'
+            assert settings.base_index == "medium_ft"
+            assert settings.custom_index == "user_all_minilm_mem"
 
     def test_get_dc_settings_environment_overrides(self):
         """Test env vars override defaults."""
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'base',
-            'DC_SV_SEARCH_BASE_URL': 'https://custom.com',
-            'DC_BASE_INDEX': 'custom_index'
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "DC_API_KEY": "test_key",
+                "DC_TYPE": "base",
+                "DC_SV_SEARCH_BASE_URL": "https://custom.com",
+                "DC_BASE_INDEX": "custom_index",
+            },
+        ):
             settings = get_dc_settings()
-            
-            assert settings.sv_search_base_url == 'https://custom.com'
-            assert settings.base_index == 'custom_index'
-            
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'custom',
-            'CUSTOM_DC_URL': 'https://test.com',
-            'DC_SEARCH_SCOPE': 'base_only',
-            'DC_BASE_INDEX': 'custom_base_index',
-            'DC_CUSTOM_INDEX': 'custom_custom_index'
-        }):
+
+            assert settings.sv_search_base_url == "https://custom.com"
+            assert settings.base_index == "custom_index"
+
+        with patch.dict(
+            os.environ,
+            {
+                "DC_API_KEY": "test_key",
+                "DC_TYPE": "custom",
+                "CUSTOM_DC_URL": "https://test.com",
+                "DC_SEARCH_SCOPE": "base_only",
+                "DC_BASE_INDEX": "custom_base_index",
+                "DC_CUSTOM_INDEX": "custom_custom_index",
+            },
+        ):
             settings = get_dc_settings()
-            
+
             assert settings.search_scope == SearchScope.BASE_ONLY
-            assert settings.base_index == 'custom_base_index'
-            assert settings.custom_index == 'custom_custom_index'
+            assert settings.base_index == "custom_base_index"
+            assert settings.custom_index == "custom_custom_index"
 
     def test_get_dc_settings_search_scope_enum(self):
         """Test SearchScope enum conversion."""
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'custom',
-            'CUSTOM_DC_URL': 'https://test.com',
-            'DC_SEARCH_SCOPE': 'custom_only'
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "DC_API_KEY": "test_key",
+                "DC_TYPE": "custom",
+                "CUSTOM_DC_URL": "https://test.com",
+                "DC_SEARCH_SCOPE": "custom_only",
+            },
+        ):
             settings = get_dc_settings()
             assert settings.search_scope == SearchScope.CUSTOM_ONLY
-            
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'custom',
-            'CUSTOM_DC_URL': 'https://test.com',
-            'DC_SEARCH_SCOPE': 'base_only'
-        }):
+
+        with patch.dict(
+            os.environ,
+            {
+                "DC_API_KEY": "test_key",
+                "DC_TYPE": "custom",
+                "CUSTOM_DC_URL": "https://test.com",
+                "DC_SEARCH_SCOPE": "base_only",
+            },
+        ):
             settings = get_dc_settings()
             assert settings.search_scope == SearchScope.BASE_ONLY
 
     def test_get_dc_settings_root_topic_dcids(self):
         """Test root topic DCIDs parsing."""
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'custom',
-            'CUSTOM_DC_URL': 'https://test.com',
-            'DC_ROOT_TOPIC_DCIDS': 'topic1,topic2,topic3'
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "DC_API_KEY": "test_key",
+                "DC_TYPE": "custom",
+                "CUSTOM_DC_URL": "https://test.com",
+                "DC_ROOT_TOPIC_DCIDS": "topic1,topic2,topic3",
+            },
+        ):
             settings = get_dc_settings()
-            assert settings.root_topic_dcids == ['topic1', 'topic2', 'topic3']
+            assert settings.root_topic_dcids == ["topic1", "topic2", "topic3"]
 
     def test_get_dc_settings_topic_cache_path(self):
         """Test topic cache path."""
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'base',
-            'DC_TOPIC_CACHE_PATH': '/path/to/cache.json'
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "DC_API_KEY": "test_key",
+                "DC_TYPE": "base",
+                "DC_TOPIC_CACHE_PATH": "/path/to/cache.json",
+            },
+        ):
             settings = get_dc_settings()
-            assert settings.topic_cache_path == '/path/to/cache.json'
+            assert settings.topic_cache_path == "/path/to/cache.json"
 
     def test_get_dc_settings_default_dc_type(self):
         """Test that DC_TYPE defaults to 'base' when not provided."""
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key'
-        }):
+        with patch.dict(os.environ, {"DC_API_KEY": "test_key"}):
             settings = get_dc_settings()
-            assert settings.dc_type == 'base'
+            assert settings.dc_type == "base"
             assert isinstance(settings, BaseDCSettings)
 
 
@@ -192,37 +202,40 @@ class TestSettingsClasses:
 
     def test_base_dc_settings_direct(self):
         """Test BaseDCSettings class directly."""
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'base'
-        }):
+        with patch.dict(os.environ, {"DC_API_KEY": "test_key", "DC_TYPE": "base"}):
             settings = BaseDCSettings()
-            
-            assert settings.dc_type == 'base'
-            assert settings.api_key == 'test_key'
-            assert settings.sv_search_base_url == 'https://datacommons.org'
-            assert settings.base_index == 'base_uae_mem'
+
+            assert settings.dc_type == "base"
+            assert settings.api_key == "test_key"
+            assert settings.sv_search_base_url == "https://datacommons.org"
+            assert settings.base_index == "base_uae_mem"
 
     def test_custom_dc_settings_direct(self):
         """Test CustomDCSettings class directly."""
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'custom',
-            'CUSTOM_DC_URL': 'https://test.com'
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "DC_API_KEY": "test_key",
+                "DC_TYPE": "custom",
+                "CUSTOM_DC_URL": "https://test.com",
+            },
+        ):
             settings = CustomDCSettings()
-            
-            assert settings.dc_type == 'custom'
-            assert settings.api_key == 'test_key'
-            assert settings.custom_dc_url == 'https://test.com'
-            assert settings.api_base_url == 'https://test.com/core/api/v2/'
+
+            assert settings.dc_type == "custom"
+            assert settings.api_key == "test_key"
+            assert settings.custom_dc_url == "https://test.com"
+            assert settings.api_base_url == "https://test.com/core/api/v2/"
 
     def test_settings_field_aliases(self):
         """Test that field aliases work correctly."""
-        with patch.dict(os.environ, {
-            'DC_API_KEY': 'test_key',
-            'DC_TYPE': 'base',
-            'DC_SV_SEARCH_BASE_URL': 'https://custom.com'
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "DC_API_KEY": "test_key",
+                "DC_TYPE": "base",
+                "DC_SV_SEARCH_BASE_URL": "https://custom.com",
+            },
+        ):
             settings = BaseDCSettings()
-            assert settings.sv_search_base_url == 'https://custom.com'
+            assert settings.sv_search_base_url == "https://custom.com"

--- a/packages/datacommons-test-agents/datacommons_test_agents/basic_agent/evals/agent_test.py
+++ b/packages/datacommons-test-agents/datacommons_test_agents/basic_agent/evals/agent_test.py
@@ -10,6 +10,8 @@ async def test_basic_agent():
     """Test the agent's basic ability via a session file."""
     await AgentEvaluator.evaluate(
         agent_module="datacommons_test_agents.basic_agent.bootstrap",
-        eval_dataset_file_path_or_dir=str(parent_path / "data/get_observations.test.json"),
+        eval_dataset_file_path_or_dir=str(
+            parent_path / "data/get_observations.test.json"
+        ),
         num_runs=2,
     )


### PR DESCRIPTION
Ran `uv run ruff format`. 

Will follow up with https://github.com/datacommonsorg/agent-toolkit/pull/30 to ensure formatting is always run + some other cleanups.