### PR TITLE
Support searching in lookup mode with no places

### DIFF
--- a/packages/datacommons-mcp/datacommons_mcp/server.py
+++ b/packages/datacommons-mcp/datacommons_mcp/server.py
@@ -96,6 +96,8 @@ async def get_observations(
     * **Mode Selection**:
         * To get data for the specified place (e.g., California), **do not** provide `child_place_type`.
         * To get data for all its children (e.g., all counties in California), you **must also** provide the `child_place_type` (e.g., "County"). Use the `validate_child_place_types` tool to find valid types.
+          **CRITICAL:** Before calling `get_observations` with `child_place_type`, you **MUST** first call the `validate_child_place_types` tool to find valid types.
+          Only proceed with `get_observations` if `validate_child_place_types` confirms that the `child_place_type` is valid for the specified parent place.
 
     * **Data Volume Constraint**: When using **Child Places Mode** (when `child_place_type` is set), you **must** be conservative with your date range to avoid requesting too much data.
         * Avoid requesting `'all'` data via the `period` parameter.
@@ -384,14 +386,12 @@ async def search_indicators(
 
     **Mode: "lookup"**
     - **Purpose**: Direct variable search for specific data needs
-    - **Use when**: You have a specific query AND at least one place - otherwise use browse mode
+    - **Use when**: You have a specific query
     - **Returns**: Variables only (no topic hierarchy)
     - **Example use cases**:
         - "Find unemployment rate variables for United States"
         - "Get population data variables for India"
         - "Search for carbon emission variables in NYC"
-
-    **Important**: If no places are provided, the tool automatically uses browse mode regardless of the mode parameter.
 
     **How to Use This Tool:**
 
@@ -417,7 +417,7 @@ async def search_indicators(
         query (str): The search query for indicators (topics, categories, or variables).
             Examples: "health grants", "carbon emissions", "unemployment rate"
         mode (str, optional): Search mode - "browse" (topics + variables) or "lookup" (variables only).
-            Default: "browse" (if not specified). Note: If no places are provided, browse mode is used regardless.
+            Default: "browse" (if not specified).
         place1_name (str, optional): First place name for filtering and existence checks.
             Examples: "France", "United States", "California"
         place2_name (str, optional): Second place name for filtering and existence checks.
@@ -458,7 +458,6 @@ async def search_indicators(
     **Best Practices:**
     - Use **"browse"** when you want to understand data organization and discover collections of variables (topics) or related variables
     - Use **"lookup"** only when you have a specific query AND at least one place
-    - If no places are provided, the tool automatically uses browse mode for better results
     - Both modes support place filtering and bilateral queries
     - Both modes use sophisticated query rewriting logic for optimal results
     """

--- a/packages/datacommons-mcp/tests/test_dc_client.py
+++ b/packages/datacommons-mcp/tests/test_dc_client.py
@@ -28,6 +28,7 @@ import pytest
 from datacommons_client.client import DataCommonsClient
 from datacommons_mcp.clients import DCClient, create_dc_client
 from datacommons_mcp.data_models.enums import SearchScope
+from datacommons_mcp.data_models.search import SearchMode
 from datacommons_mcp.data_models.observations import (
     DateRange,
     ObservationApiResponse,
@@ -457,11 +458,11 @@ class TestDCClientObservations:
         )
 
 
-class TestDCClientFetchTopicsAndVariables:
-    """Tests for the fetch_topics_and_variables method of DCClient."""
+class TestDCClientFetchIndicators:
+    """Tests for the fetch_indicators method of DCClient."""
 
     @pytest.mark.asyncio
-    async def test_fetch_topics_and_variables_basic(self, mocked_datacommons_client):
+    async def test_fetch_indicators_browse_mode_basic(self, mocked_datacommons_client):
         """Test basic functionality without place filtering."""
         # Arrange: Create client and mock search results
         client_under_test = DCClient(dc=mocked_datacommons_client)
@@ -499,7 +500,9 @@ class TestDCClientFetchTopicsAndVariables:
         }
 
         # Act: Call the method
-        result = await client_under_test.fetch_topics_and_variables("test query")
+        result = await client_under_test.fetch_indicators(
+            "test query", mode=SearchMode.BROWSE
+        )
 
         # Assert: Verify the response structure
         assert "topics" in result
@@ -524,7 +527,78 @@ class TestDCClientFetchTopicsAndVariables:
         assert result["lookups"]["dc/variable/Count_Person"] == "Count of Persons"
 
     @pytest.mark.asyncio
-    async def test_fetch_topics_and_variables_with_places(
+    async def test_fetch_indicators_lookup_mode_basic(self, mocked_datacommons_client):
+        """Test basic functionality without place filtering."""
+        # Arrange: Create client and mock search results
+        client_under_test = DCClient(dc=mocked_datacommons_client)
+
+        # Mock search_svs to return topics and variables
+        mock_search_results = {
+            "test query": [
+                {"SV": "dc/topic/Health", "CosineScore": 0.9},
+                {"SV": "dc/topic/Economy", "CosineScore": 0.8},
+                {"SV": "dc/variable/Count_Person", "CosineScore": 0.7},
+                {"SV": "dc/variable/Count_Household", "CosineScore": 0.6},
+            ]
+        }
+
+        # Mock the search_svs method
+        client_under_test.search_svs = AsyncMock(return_value=mock_search_results)
+
+        # Mock topic store
+        client_under_test.topic_store = Mock()
+        client_under_test.topic_store.get_name.side_effect = lambda dcid: {
+            "dc/variable/Count_Health": "Count of Health",
+            "dc/variable/Count_Economy": "Count of Economy",
+            "dc/variable/Count_Person": "Count of Persons",
+            "dc/variable/Count_Household": "Count of Households",
+        }.get(dcid, dcid)
+
+        # Mock topic data
+        client_under_test.topic_store.topics_by_dcid = {
+            "dc/topic/Health": Mock(
+                member_topics=[], variables=["dc/variable/Count_Person"]
+            ),
+            "dc/topic/Economy": Mock(
+                member_topics=[], variables=["dc/variable/Count_Household"]
+            ),
+        }
+
+        client_under_test.topic_store.get_topic_variables.side_effect = lambda dcid: {
+            "dc/topic/Health": ["dc/variable/Count_Health"],
+            "dc/topic/Economy": ["dc/variable/Count_Economy"],
+        }.get(dcid, [])
+
+        # Act: Call the method
+        result = await client_under_test.fetch_indicators(
+            "test query", mode=SearchMode.LOOKUP
+        )
+
+        # Assert: Verify the response structure
+        assert "topics" in result
+        assert "variables" in result
+        assert "lookups" in result
+
+        # Verify topics
+        assert len(result["topics"]) == 0
+
+        # Verify variables
+        assert len(result["variables"]) == 4
+        variable_dcids = [var["dcid"] for var in result["variables"]]
+        assert variable_dcids == [
+            "dc/variable/Count_Health",
+            "dc/variable/Count_Economy",
+            "dc/variable/Count_Person",
+            "dc/variable/Count_Household",
+        ]
+
+        # Verify lookups
+        assert len(result["lookups"]) == 4
+        assert result["lookups"]["dc/variable/Count_Health"] == "Count of Health"
+        assert result["lookups"]["dc/variable/Count_Person"] == "Count of Persons"
+
+    @pytest.mark.asyncio
+    async def test_fetch_indicators_browse_mode_with_places(
         self, mocked_datacommons_client
     ):
         """Test functionality with place filtering."""
@@ -565,8 +639,8 @@ class TestDCClientFetchTopicsAndVariables:
         }.get(place_dcid, set())
 
         # Act: Call the method with place filtering
-        result = await client_under_test.fetch_topics_and_variables(
-            "test query", place_dcids=["geoId/06", "geoId/36"]
+        result = await client_under_test.fetch_indicators(
+            "test query", mode=SearchMode.BROWSE, place_dcids=["geoId/06", "geoId/36"]
         )
 
         # Assert: Verify that only variables with data are returned
@@ -701,7 +775,9 @@ class TestDCClientFetchTopicsAndVariables:
         }
 
         # Act: Call the method
-        result = await client_under_test._search_entities("test query")
+        result = await client_under_test._search_indicators(
+            "test query", mode=SearchMode.BROWSE
+        )
 
         # Assert: Verify that only valid topics are returned
         assert "topics" in result
@@ -740,7 +816,9 @@ class TestDCClientFetchTopicsAndVariables:
         client_under_test.topic_store = None
 
         # Act: Call the method
-        result = await client_under_test._search_entities("test query")
+        result = await client_under_test._search_indicators(
+            "test query", mode=SearchMode.BROWSE
+        )
 
         # Assert: Verify that no topics are returned when topic store is None
         assert "topics" in result
@@ -769,7 +847,9 @@ class TestDCClientFetchTopicsAndVariables:
         }
         client_under_test.search_svs = AsyncMock(return_value=mock_search_results)
 
-        result = await client_under_test._search_entities("test query", max_results=2)
+        result = await client_under_test._search_indicators(
+            "test query", mode=SearchMode.BROWSE, max_results=2
+        )
 
         # Verify that search_svs was called with max_results=2
         client_under_test.search_svs.assert_called_once_with(


### PR DESCRIPTION
* Follow up to this comment in a previous PR to support lookup mode without requiring a place: https://github.com/datacommonsorg/agent-toolkit/pull/31#discussion_r2317524888
* In doing this, we've consolidated the implementation of the modes
  + In that, both browse and lookup modes follow the same code paths
  + The key difference is that with browse mode we return topics whereas with lookup mode we expand topic variables and return only variables
* Went through the same workflows as mentioned in this PR as a manual verification step: https://github.com/datacommonsorg/agent-toolkit/pull/31