### PR TITLE
Fix search_indicators regression for certain bilateral queries

### DIFF
--- a/packages/datacommons-mcp/datacommons_mcp/cache.py
+++ b/packages/datacommons-mcp/datacommons_mcp/cache.py
@@ -13,33 +13,38 @@
 # limitations under the License.
 
 import collections
+import threading
 
 
 class LruCache:
     """
     A simple implementation of an in-memory LRU cache.
+    Thread-safe for concurrent access.
     """
 
     def __init__(self, capacity: int) -> None:
         self.cache = collections.OrderedDict()
         self.capacity = capacity
+        self._lock = threading.RLock()
 
     def get(self, key: str) -> set[str]:
         """
         Retrieves an item from the cache and marks it as recently used.
         Returns None if the key is not found.
         """
-        if key not in self.cache:
-            return None
-        self.cache.move_to_end(key)
-        return self.cache[key]
+        with self._lock:
+            if key not in self.cache:
+                return None
+            self.cache.move_to_end(key)
+            return self.cache[key]
 
     def put(self, key: str, value: set[str]) -> None:
         """
         Adds an item to the cache. If the cache is full, the least
         recently used item is removed.
         """
-        self.cache[key] = value
-        self.cache.move_to_end(key)
-        if len(self.cache) > self.capacity:
-            self.cache.popitem(last=False)
+        with self._lock:
+            self.cache[key] = value
+            self.cache.move_to_end(key)
+            if len(self.cache) > self.capacity:
+                self.cache.popitem(last=False)

--- a/packages/datacommons-mcp/datacommons_mcp/clients.py
+++ b/packages/datacommons-mcp/datacommons_mcp/clients.py
@@ -512,7 +512,6 @@ class DCClient:
 
         # Check which variables exist for any of the places
         existing_variables = []
-        non_existing_variables = []
         for var in variable_dcids:
             places_with_data = []
             for place_dcid in place_dcids:
@@ -520,17 +519,12 @@ class DCClient:
                 if place_variables is not None and var in place_variables:
                     places_with_data.append(place_dcid)
 
-            variable_info = {"dcid": var, "places_with_data": places_with_data}
             if places_with_data:
-                existing_variables.append(variable_info)
-            else:
-                non_existing_variables.append(variable_info)
+                existing_variables.append(
+                    {"dcid": var, "places_with_data": places_with_data}
+                )
 
-        # Return existing variables if they exist, otherwise return non-existing variables
-        if existing_variables:
-            return existing_variables
-        else:
-            return non_existing_variables
+        return existing_variables
 
     def _filter_topics_by_existence(
         self, topic_dcids: list[str], place_dcids: list[str]

--- a/packages/datacommons-mcp/datacommons_mcp/server.py
+++ b/packages/datacommons-mcp/datacommons_mcp/server.py
@@ -400,18 +400,23 @@ async def search_indicators(
 
     **How to Use This Tool:**
 
+    * The examples below exclude the mode parameter intentionally. The calls can be made in both modes. Choose the mode based on the mode selection guidelines above.
+
     * **For non-bilateral place-constrained queries** like "population of France":
-        - Call with `query="population"`, `mode="lookup"`, `places=["France"]`, and `maybe_bilateral=False`
+        - Call with `query="population"`, `places=["France"]`, and `maybe_bilateral=False`
         - The tool will match indicators and perform existence checks for the specified place
 
     * **For place-constrained queries** where the agent deems the indicator *could* represent a bilateral relationship like "trade exports to France":
-        - Call with `query="trade exports"`, `mode="lookup"`, `places=["France"]`, and `maybe_bilateral=True`
+        - Call with `query="trade exports"`, `places=["France"]`, and `maybe_bilateral=True`
         - The tool will match indicators and perform existence checks for the specified place
 
-    * **For bilateral place-constrained queries** like "trade exports from USA to France":
-        - Call with `query="trade exports"`, `mode="lookup"`, `places=["USA", "France"]`, and `maybe_bilateral=True`
-        - The tool will match indicators and perform existence checks for both places
-        - In bilateral data, one place (e.g., "France") is encoded in the variable name, while the other place (e.g., "USA") is where we have observations
+    * **For bilateral place-constrained queries**:
+        - between two places like "trade exports from USA to France":
+          + Call with `query="trade exports"`, `places=["USA", "France"]`, and `maybe_bilateral=True`
+        - between multiple places like "trade exports from USA, Germany and UK to France":
+          + Call with `query="trade exports"`, `places=["USA", "Germany", "UK", "France"]`, and `maybe_bilateral=True`
+        - The tool will match indicators and perform existence checks for the specified places
+        - In bilateral data, one place (e.g., "France") is encoded in the variable name, while the other place (e.g., "USA", "Germany", "UK") is where we have observations
         - Use `places_with_data` to identify which place has observations
 
     * **For child entity sampling** like "population of Indian states":
@@ -420,11 +425,11 @@ async def search_indicators(
         - Results are indicative of broader child entity coverage
 
     * **For exploratory queries** like "what basic health data do you have":
-        - Call with `query="health"` and `mode="browse"` (or omit mode parameter)
+        - Call with `query="basic health"`
         - The tool will return organized topic categories and variables
 
     * **For non-place-constrained queries** like "what trade data do you have":
-        - Call with just the `query` parameter (automatically uses browse mode)
+        - Call with `query="trade"`
         - No place existence checks are performed
 
     Args:
@@ -479,42 +484,12 @@ async def search_indicators(
     - Both modes support place filtering and bilateral queries
     - Both modes use sophisticated query rewriting logic for optimal results
     """
-    # TODO: Phase 1 - Dummy response for manual testing
-    # Will implement business logic in Phase 2
-    
-    # Convert parameters to string representations for debugging
-    places_str = ",".join(places) if places else "None"
-    
-    return SearchResponse(
-        topics=[
-            SearchTopic(
-                dcid="dummy_topic_1",
-                member_topics=[],
-                member_variables=["dummy_var_1", "dummy_var_2"],
-                places_with_data=None
-            )
-        ],
-        variables=[
-            SearchVariable(
-                dcid="dummy_var_1",
-                places_with_data=["dummy_place_1"]
-            ),
-            SearchVariable(
-                dcid="dummy_var_2", 
-                places_with_data=["dummy_place_2"]
-            )
-        ],
-        dcid_name_mappings={
-            "dummy_topic_1": "DUMMY TOPIC - Phase 1 Testing",
-            "dummy_var_1": "DUMMY VARIABLE 1 - Phase 1 Testing",
-            "dummy_var_2": "DUMMY VARIABLE 2 - Phase 1 Testing",
-            "dummy_place_1": "DUMMY PLACE 1 - Phase 1 Testing",
-            "dummy_place_2": "DUMMY PLACE 2 - Phase 1 Testing",
-            # Tool parameters for debugging
-            "query": f'"{query}"',
-            "mode": f'"{mode}"',
-            "places": f'[{places_str}]',
-            "maybe_bilateral": str(maybe_bilateral),
-            "per_search_limit": str(per_search_limit)
-        }
+    # Call the real search_indicators service
+    return await search_indicators_service(
+        client=dc_client,
+        query=query,
+        mode=mode,
+        places=places,
+        maybe_bilateral=maybe_bilateral,
+        per_search_limit=per_search_limit,
     )

--- a/packages/datacommons-mcp/datacommons_mcp/services.py
+++ b/packages/datacommons-mcp/datacommons_mcp/services.py
@@ -193,9 +193,6 @@ def _create_search_tasks(
                 )
 
         # Original query search last
-        place_dcids = [
-            place_dcids_map.get(name) for name in places if place_dcids_map.get(name)
-        ]
         search_tasks.append(SearchTask(query=query, place_dcids=place_dcids))
 
     elif places:

--- a/packages/datacommons-mcp/datacommons_mcp/services.py
+++ b/packages/datacommons-mcp/datacommons_mcp/services.py
@@ -126,22 +126,18 @@ async def search_indicators(
     query: str,
     mode: SearchModeType | None = None,
     places: list[str] | None = None,
-    bilateral_places: list[str] | None = None,
+    maybe_bilateral: bool = False,
     per_search_limit: int = 10,
 ) -> SearchResponse:
     """Search for topics and/or variables based on mode."""
     # Validate parameters and convert mode to enum
-    search_mode = _validate_search_parameters(
-        mode, places, bilateral_places, per_search_limit
-    )
+    search_mode = _validate_search_parameters(mode, per_search_limit)
 
     # Resolve place names to DCIDs
-    place_dcids_map = await _resolve_places(client, places, bilateral_places)
+    place_dcids_map = await _resolve_places(client, places)
 
     # Create search tasks based on place parameters
-    search_tasks = _create_search_tasks(
-        query, places, bilateral_places, place_dcids_map
-    )
+    search_tasks = _create_search_tasks(query, places, maybe_bilateral, place_dcids_map)
 
     search_result = await _search_indicators(
         client, search_mode, search_tasks, per_search_limit
@@ -165,15 +161,15 @@ async def search_indicators(
 def _create_search_tasks(
     query: str,
     places: list[str] | None,
-    bilateral_places: list[str] | None,
+    maybe_bilateral: bool,
     place_dcids_map: dict[str, str],
 ) -> list[SearchTask]:
     """Create search tasks based on place parameters.
 
     Args:
         query: The search query
-        places: List of place names (mutually exclusive with bilateral_places)
-        bilateral_places: List of exactly 2 place names (mutually exclusive with places)
+        places: List of place names
+        maybe_bilateral: Whether to include bilateral relationship searches
         place_dcids_map: Mapping of place names to DCIDs
 
     Returns:
@@ -181,45 +177,35 @@ def _create_search_tasks(
     """
     search_tasks = []
 
-    if places:
-        # Single search task with all place DCIDs (no query rewriting)
+    if places and maybe_bilateral:
+        # Place-specific searches first (one per place)
+        for place_name in places:
+            place_dcid = place_dcids_map.get(place_name)
+            if place_dcid:
+                # Include all DCIDs except the current place
+                other_place_dcids = [
+                    dcid
+                    for name, dcid in place_dcids_map.items()
+                    if name != place_name and dcid
+                ]
+                search_tasks.append(
+                    SearchTask(
+                        query=f"{query} {place_name}", place_dcids=other_place_dcids
+                    )
+                )
+
+        # Original query search last
         place_dcids = [
             place_dcids_map.get(name) for name in places if place_dcids_map.get(name)
         ]
         search_tasks.append(SearchTask(query=query, place_dcids=place_dcids))
 
-    elif bilateral_places:
-        # Three search tasks with query rewriting (same as current behavior)
-        place1_name, place2_name = bilateral_places
-        place1_dcid = place_dcids_map.get(place1_name)
-        place2_dcid = place_dcids_map.get(place2_name)
-
-        # Base query: search for the original query, filter by all available places
-        base_place_dcids = []
-        if place1_dcid:
-            base_place_dcids.append(place1_dcid)
-        if place2_dcid:
-            base_place_dcids.append(place2_dcid)
-
-        search_tasks.append(SearchTask(query=query, place_dcids=base_place_dcids))
-
-        # Place1 query: search for query + place1_name, filter by place2_dcid
-        if place1_dcid:
-            search_tasks.append(
-                SearchTask(
-                    query=f"{query} {place1_name}",
-                    place_dcids=[place2_dcid] if place2_dcid else [],
-                )
-            )
-
-        # Place2 query: search for query + place2_name, filter by place1_dcid
-        if place2_dcid:
-            search_tasks.append(
-                SearchTask(
-                    query=f"{query} {place2_name}",
-                    place_dcids=[place1_dcid] if place1_dcid else [],
-                )
-            )
+    elif places:
+        # Single search task with all place DCIDs (no query rewriting)
+        place_dcids = [
+            place_dcids_map.get(name) for name in places if place_dcids_map.get(name)
+        ]
+        search_tasks.append(SearchTask(query=query, place_dcids=place_dcids))
 
     else:
         # No places: single search task with no place constraints
@@ -230,16 +216,12 @@ def _create_search_tasks(
 
 def _validate_search_parameters(
     mode: SearchModeType | None,
-    places: list[str] | None,
-    bilateral_places: list[str] | None,
     per_search_limit: int,
 ) -> SearchMode:
     """Validate search parameters and convert mode to enum.
 
     Args:
         mode: Search mode string or None
-        places: List of place names (mutually exclusive with bilateral_places)
-        bilateral_places: List of exactly 2 place names (mutually exclusive with places)
         per_search_limit: Maximum results per search
 
     Returns:
@@ -263,27 +245,18 @@ def _validate_search_parameters(
     if not 1 <= per_search_limit <= 100:
         raise ValueError("per_search_limit must be between 1 and 100")
 
-    # Validate place parameters
-    if places is not None and bilateral_places is not None:
-        raise ValueError("Cannot specify both 'places' and 'bilateral_places'")
-
-    if bilateral_places is not None and len(bilateral_places) != 2:
-        raise ValueError("bilateral_places must contain exactly 2 place names")
-
     return search_mode
 
 
 async def _resolve_places(
     client: DCClient,
     places: list[str] | None,
-    bilateral_places: list[str] | None,
 ) -> dict[str, str]:
     """Resolve place names to DCIDs.
 
     Args:
         client: DCClient instance for place resolution
-        places: List of place names (mutually exclusive with bilateral_places)
-        bilateral_places: List of exactly 2 place names (mutually exclusive with places)
+        places: List of place names
 
     Returns:
         Dictionary mapping place names to DCIDs
@@ -291,13 +264,12 @@ async def _resolve_places(
     Raises:
         DataLookupError: If place resolution fails
     """
-    place_names = places or bilateral_places or []
 
-    if not place_names:
+    if not places:
         return {}
 
     try:
-        return await client.search_places(place_names)
+        return await client.search_places(places)
     except Exception as e:
         msg = "Error resolving place names"
         logger.error("%s: %s", msg, e)

--- a/packages/datacommons-mcp/datacommons_mcp/services.py
+++ b/packages/datacommons-mcp/datacommons_mcp/services.py
@@ -176,22 +176,20 @@ def _create_search_tasks(
         List of SearchTask objects
     """
     search_tasks = []
+    place_dcids = (
+        [place_dcids_map.get(name) for name in places if place_dcids_map.get(name)]
+        if places and place_dcids_map
+        else []
+    )
 
     if places and maybe_bilateral:
         # Place-specific searches first (one per place)
         for place_name in places:
             place_dcid = place_dcids_map.get(place_name)
             if place_dcid:
-                # Include all DCIDs except the current place
-                other_place_dcids = [
-                    dcid
-                    for name, dcid in place_dcids_map.items()
-                    if name != place_name and dcid
-                ]
+                # Rewrite query to include place name and include all place DCIDs
                 search_tasks.append(
-                    SearchTask(
-                        query=f"{query} {place_name}", place_dcids=other_place_dcids
-                    )
+                    SearchTask(query=f"{query} {place_name}", place_dcids=place_dcids)
                 )
 
         # Original query search last
@@ -202,9 +200,6 @@ def _create_search_tasks(
 
     elif places:
         # Single search task with all place DCIDs (no query rewriting)
-        place_dcids = [
-            place_dcids_map.get(name) for name in places if place_dcids_map.get(name)
-        ]
         search_tasks.append(SearchTask(query=query, place_dcids=place_dcids))
 
     else:

--- a/packages/datacommons-mcp/tests/test_services.py
+++ b/packages/datacommons-mcp/tests/test_services.py
@@ -374,7 +374,8 @@ class TestSearchIndicators:
             client=mock_client,
             query="trade",
             mode="lookup",
-            bilateral_places=["France", "Germany"],
+            places=["France", "Germany"],
+            maybe_bilateral=True,
         )
 
         # Should have deduplicated variables in expected order
@@ -535,8 +536,8 @@ class TestSearchIndicators:
         )
 
     @pytest.mark.asyncio
-    async def test_search_indicators_bilateral_places_behavior(self):
-        """Test bilateral_places parameter behavior across browse and lookup modes."""
+    async def test_search_indicators_maybe_bilateral_behavior(self):
+        """Test maybe_bilateral parameter behavior across browse and lookup modes."""
         mock_client = Mock()
         mock_client.search_places = AsyncMock(
             return_value={"USA": "country/USA", "France": "country/FRA"}
@@ -544,12 +545,13 @@ class TestSearchIndicators:
         mock_client.fetch_indicators = AsyncMock(return_value={})
         mock_client.fetch_entity_names = Mock(return_value={})
 
-        # Test 1: Bilateral places in browse mode
+        # Test 1: Maybe bilateral in browse mode
         result = await search_indicators(
             client=mock_client,
             query="trade exports",
             mode="browse",
-            bilateral_places=["USA", "France"],
+            places=["USA", "France"],
+            maybe_bilateral=True,
         )
         assert result.status == "SUCCESS"
         mock_client.search_places.assert_called_with(["USA", "France"])
@@ -557,25 +559,25 @@ class TestSearchIndicators:
 
         # Assert the actual queries fetch_indicators was called with
         calls = mock_client.fetch_indicators.call_args_list
-        # The first call should be just the base query with both place DCIDs
+        # The first call should be with USA appended to query, filtered by France
         assert calls[0].kwargs == {
-            "query": "trade exports",
-            "mode": SearchMode.BROWSE,
-            "place_dcids": ["country/USA", "country/FRA"],
-            "max_results": 10,
-        }
-        # The second call should be with USA appended to query, filtered by France
-        assert calls[1].kwargs == {
             "query": "trade exports USA",
             "mode": SearchMode.BROWSE,
             "place_dcids": ["country/FRA"],
             "max_results": 10,
         }
-        # The third call should be with France appended to query, filtered by USA
-        assert calls[2].kwargs == {
+        # The second call should be with France appended to query, filtered by USA
+        assert calls[1].kwargs == {
             "query": "trade exports France",
             "mode": SearchMode.BROWSE,
             "place_dcids": ["country/USA"],
+            "max_results": 10,
+        }
+        # The third call should be the original query with both place DCIDs
+        assert calls[2].kwargs == {
+            "query": "trade exports",
+            "mode": SearchMode.BROWSE,
+            "place_dcids": ["country/USA", "country/FRA"],
             "max_results": 10,
         }
 
@@ -587,12 +589,13 @@ class TestSearchIndicators:
         mock_client.fetch_indicators = AsyncMock(return_value={})
         mock_client.fetch_entity_names = Mock(return_value={})
 
-        # Test 2: Bilateral places in lookup mode
+        # Test 2: Maybe bilateral in lookup mode
         result = await search_indicators(
             client=mock_client,
             query="trade exports",
             mode="lookup",
-            bilateral_places=["USA", "France"],
+            places=["USA", "France"],
+            maybe_bilateral=True,
         )
         assert result.status == "SUCCESS"
         mock_client.search_places.assert_called_with(["USA", "France"])
@@ -600,25 +603,25 @@ class TestSearchIndicators:
 
         # Assert the same query rewriting behavior
         calls = mock_client.fetch_indicators.call_args_list
-        # The first call should be just the base query with both place DCIDs
+        # The first call should be with USA appended to query, filtered by France
         assert calls[0].kwargs == {
-            "query": "trade exports",
-            "mode": SearchMode.LOOKUP,
-            "place_dcids": ["country/USA", "country/FRA"],
-            "max_results": 10,
-        }
-        # The second call should be with USA appended to query, filtered by France
-        assert calls[1].kwargs == {
             "query": "trade exports USA",
             "mode": SearchMode.LOOKUP,
             "place_dcids": ["country/FRA"],
             "max_results": 10,
         }
-        # The third call should be with France appended to query, filtered by USA
-        assert calls[2].kwargs == {
+        # The second call should be with France appended to query, filtered by USA
+        assert calls[1].kwargs == {
             "query": "trade exports France",
             "mode": SearchMode.LOOKUP,
             "place_dcids": ["country/USA"],
+            "max_results": 10,
+        }
+        # The third call should be the original query with both place DCIDs
+        assert calls[2].kwargs == {
+            "query": "trade exports",
+            "mode": SearchMode.LOOKUP,
+            "place_dcids": ["country/USA", "country/FRA"],
             "max_results": 10,
         }
 
@@ -632,35 +635,32 @@ class TestSearchIndicators:
         mock_client.fetch_indicators = AsyncMock(return_value={"variables": []})
         mock_client.fetch_entity_names = Mock(return_value={})
 
-        # Test both places and bilateral_places specified (should raise ValueError)
-        with pytest.raises(
-            ValueError, match="Cannot specify both 'places' and 'bilateral_places'"
-        ):
-            await search_indicators(
-                client=mock_client,
-                query="test",
-                places=["USA"],
-                bilateral_places=["USA", "France"],
-            )
+        # Test maybe_bilateral=True with places (should work)
+        result = await search_indicators(
+            client=mock_client,
+            query="test",
+            places=["USA", "France"],
+            maybe_bilateral=True,
+        )
+        assert result.status == "SUCCESS"
+        assert mock_client.fetch_indicators.call_count == 3  # len(places) + 1
 
-        # Test bilateral_places with != 2 items (should raise ValueError)
-        with pytest.raises(
-            ValueError, match="bilateral_places must contain exactly 2 place names"
-        ):
-            await search_indicators(
-                client=mock_client,
-                query="test",
-                bilateral_places=["USA"],  # Only 1 place
-            )
+        # Test maybe_bilateral=False with places (should work)
+        mock_client.reset_mock()
+        mock_client.search_places = AsyncMock(
+            return_value={"USA": "country/USA", "France": "country/FRA"}
+        )
+        mock_client.fetch_indicators = AsyncMock(return_value={"variables": []})
+        mock_client.fetch_entity_names = Mock(return_value={})
 
-        with pytest.raises(
-            ValueError, match="bilateral_places must contain exactly 2 place names"
-        ):
-            await search_indicators(
-                client=mock_client,
-                query="test",
-                bilateral_places=["USA", "France", "Germany"],  # 3 places
-            )
+        result = await search_indicators(
+            client=mock_client,
+            query="test",
+            places=["USA", "France"],
+            maybe_bilateral=False,
+        )
+        assert result.status == "SUCCESS"
+        assert mock_client.fetch_indicators.call_count == 1  # single search
 
         # Test valid combinations (should not raise)
         # Single place
@@ -679,11 +679,12 @@ class TestSearchIndicators:
         )
         assert result.status == "SUCCESS"
 
-        # Bilateral places
+        # Maybe bilateral with places
         result = await search_indicators(
             client=mock_client,
             query="test",
-            bilateral_places=["USA", "France"],
+            places=["USA", "France"],
+            maybe_bilateral=True,
         )
         assert result.status == "SUCCESS"
 

--- a/packages/datacommons-mcp/tests/test_services.py
+++ b/packages/datacommons-mcp/tests/test_services.py
@@ -559,18 +559,18 @@ class TestSearchIndicators:
 
         # Assert the actual queries fetch_indicators was called with
         calls = mock_client.fetch_indicators.call_args_list
-        # The first call should be with USA appended to query, filtered by France
+        # The first call should be with USA appended to query
         assert calls[0].kwargs == {
             "query": "trade exports USA",
             "mode": SearchMode.BROWSE,
-            "place_dcids": ["country/FRA"],
+            "place_dcids": ["country/USA", "country/FRA"],
             "max_results": 10,
         }
-        # The second call should be with France appended to query, filtered by USA
+        # The second call should be with France appended to query
         assert calls[1].kwargs == {
             "query": "trade exports France",
             "mode": SearchMode.BROWSE,
-            "place_dcids": ["country/USA"],
+            "place_dcids": ["country/USA", "country/FRA"],
             "max_results": 10,
         }
         # The third call should be the original query with both place DCIDs
@@ -603,18 +603,18 @@ class TestSearchIndicators:
 
         # Assert the same query rewriting behavior
         calls = mock_client.fetch_indicators.call_args_list
-        # The first call should be with USA appended to query, filtered by France
+        # The first call should be with USA appended to query
         assert calls[0].kwargs == {
             "query": "trade exports USA",
             "mode": SearchMode.LOOKUP,
-            "place_dcids": ["country/FRA"],
+            "place_dcids": ["country/USA", "country/FRA"],
             "max_results": 10,
         }
-        # The second call should be with France appended to query, filtered by USA
+        # The second call should be with France appended to query
         assert calls[1].kwargs == {
             "query": "trade exports France",
             "mode": SearchMode.LOOKUP,
-            "place_dcids": ["country/USA"],
+            "place_dcids": ["country/USA", "country/FRA"],
             "max_results": 10,
         }
         # The third call should be the original query with both place DCIDs


### PR DESCRIPTION
This PR fixes regressions as noted in this draft PR by @jm-rivera: https://github.com/datacommonsorg/agent-toolkit/pull/40

**Root Cause:**
The recent separation of `places` and `bilateral_places` parameters created a regression where bilateral-related queries that don't explicitly mention two places were regressing.

**Solution:**
- Replaces `bilateral_places: list[str]` with `maybe_bilateral: bool = False`
- More intuitive for agents: "trade exports to france" → `maybe_bilateral=True` (could be bilateral)
- When `maybe_bilateral=True`: makes `len(places) + 1` searches (place-specific first, original query last)
- Place-specific searches filtered by all _other_ places (bilateral pattern)

**Performance improvement:**
- Reduces the number of search tool calls an agent needs to make
- Parallelizes place variable caching for better performance