### PR TITLE
Remove mode

### DIFF
--- a/packages/datacommons-mcp/datacommons_mcp/clients.py
+++ b/packages/datacommons-mcp/datacommons_mcp/clients.py
@@ -473,12 +473,7 @@ class DCClient:
             if "/topic/" in sv_dcid:
                 # Only include topics that exist in the topic store
                 if self.topic_store and sv_dcid in self.topic_store.topics_by_dcid:
-                    for variable in self.topic_store.get_topic_variables(sv_dcid):
-                        if variable not in variable_set:
-                            variables.append(variable)
-                            variable_set.add(variable)
-                    else:
-                        topics.append(sv_dcid)
+                    topics.append(sv_dcid)
             else:
                 variables.append(sv_dcid)
                 variable_set.add(sv_dcid)

--- a/packages/datacommons-mcp/datacommons_mcp/clients.py
+++ b/packages/datacommons-mcp/datacommons_mcp/clients.py
@@ -357,14 +357,12 @@ class DCClient:
     async def fetch_indicators(
         self,
         query: str,
-        mode: SearchMode,
         place_dcids: list[str] = None,
+        include_topics: bool = True,
         max_results: int = 10,
     ) -> dict:
         """
         Search for indicators matching a query, optionally filtered by place existence.
-        When mode is SearchMode.LOOKUP, return variables only.
-        When mode is SearchMode.BROWSE, return both topics and variables.
         When place_dcids are specified, filter the results by place existence.
 
         Returns:
@@ -373,8 +371,12 @@ class DCClient:
         # Search for more results than we need to ensure we get enough topics and variables.
         # The factor of 2 is arbitrary and we can adjust it (make it configurable?) as needed.
         max_search_results = max_results * 2
-        # Search for indicators - it returns topics and / or variables based on the mode.
-        search_results = await self._search_indicators(query, mode, max_search_results)
+        # Search for indicators - it returns topics and / or variables.
+        search_results = await self._search_indicators(
+            query=query,
+            include_topics=include_topics,
+            max_results=max_search_results,
+        )
 
         # Separate topics and variables
         topics = search_results.get("topics", [])
@@ -446,21 +448,20 @@ class DCClient:
         }
 
     async def _search_indicators(
-        self, query: str, mode: SearchMode, max_results: int = 10
+        self, query: str, include_topics: bool = True, max_results: int = 10
     ) -> dict:
         """
         Search for topics and variables using search_svs.
-        When mode is SearchMode.LOOKUP, expand topics to variables.
         """
-        logger.info(f"Searching for indicators with query: {query} and mode: {mode}")
+        logger.info(f"Searching for indicators with query: {query}")
         search_results = await self.search_svs(
-            [query], skip_topics=False, max_results=max_results
+            [query], skip_topics=not include_topics, max_results=max_results
         )
         results = search_results.get(query, [])
 
         topics = []
         variables = []
-        # Track variables to avoid duplicates when expanding topics to variables in lookup mode.
+        # Track variables to avoid duplicates when expanding topics to variables.
         variable_set: set[str] = set()
 
         for result in results:
@@ -472,12 +473,10 @@ class DCClient:
             if "/topic/" in sv_dcid:
                 # Only include topics that exist in the topic store
                 if self.topic_store and sv_dcid in self.topic_store.topics_by_dcid:
-                    # In lookup mode, expand topics to variables.
-                    if mode == SearchMode.LOOKUP:
-                        for variable in self.topic_store.get_topic_variables(sv_dcid):
-                            if variable not in variable_set:
-                                variables.append(variable)
-                                variable_set.add(variable)
+                    for variable in self.topic_store.get_topic_variables(sv_dcid):
+                        if variable not in variable_set:
+                            variables.append(variable)
+                            variable_set.add(variable)
                     else:
                         topics.append(sv_dcid)
             else:

--- a/packages/datacommons-mcp/datacommons_mcp/clients.py
+++ b/packages/datacommons-mcp/datacommons_mcp/clients.py
@@ -512,7 +512,6 @@ class DCClient:
 
         # Check which variables exist for any of the places
         existing_variables = []
-        non_existing_variables = []
         for var in variable_dcids:
             places_with_data = []
             for place_dcid in place_dcids:
@@ -520,17 +519,12 @@ class DCClient:
                 if place_variables is not None and var in place_variables:
                     places_with_data.append(place_dcid)
 
-            variable_info = {"dcid": var, "places_with_data": places_with_data}
             if places_with_data:
-                existing_variables.append(variable_info)
-            else:
-                non_existing_variables.append(variable_info)
+                existing_variables.append(
+                    {"dcid": var, "places_with_data": places_with_data}
+                )
 
-        # Return existing variables if they exist, otherwise return non-existing variables
-        if existing_variables:
-            return existing_variables
-        else:
-            return non_existing_variables
+        return existing_variables
 
     def _filter_topics_by_existence(
         self, topic_dcids: list[str], place_dcids: list[str]

--- a/packages/datacommons-mcp/datacommons_mcp/server.py
+++ b/packages/datacommons-mcp/datacommons_mcp/server.py
@@ -400,18 +400,23 @@ async def search_indicators(
 
     **How to Use This Tool:**
 
+    * The examples below exclude the mode parameter intentionally. The calls can be made in both modes. Choose the mode based on the mode selection guidelines above.
+
     * **For non-bilateral place-constrained queries** like "population of France":
-        - Call with `query="population"`, `mode="lookup"`, `places=["France"]`, and `maybe_bilateral=False`
+        - Call with `query="population"`, `places=["France"]`, and `maybe_bilateral=False`
         - The tool will match indicators and perform existence checks for the specified place
 
     * **For place-constrained queries** where the agent deems the indicator *could* represent a bilateral relationship like "trade exports to France":
-        - Call with `query="trade exports"`, `mode="lookup"`, `places=["France"]`, and `maybe_bilateral=True`
+        - Call with `query="trade exports"`, `places=["France"]`, and `maybe_bilateral=True`
         - The tool will match indicators and perform existence checks for the specified place
 
-    * **For bilateral place-constrained queries** like "trade exports from USA to France":
-        - Call with `query="trade exports"`, `mode="lookup"`, `places=["USA", "France"]`, and `maybe_bilateral=True`
-        - The tool will match indicators and perform existence checks for both places
-        - In bilateral data, one place (e.g., "France") is encoded in the variable name, while the other place (e.g., "USA") is where we have observations
+    * **For bilateral place-constrained queries**:
+        - between two places like "trade exports from USA to France":
+          + Call with `query="trade exports"`, `places=["USA", "France"]`, and `maybe_bilateral=True`
+        - between multiple places like "trade exports from USA, Germany and UK to France":
+          + Call with `query="trade exports"`, `places=["USA", "Germany", "UK", "France"]`, and `maybe_bilateral=True`
+        - The tool will match indicators and perform existence checks for the specified places
+        - In bilateral data, one place (e.g., "France") is encoded in the variable name, while the other place (e.g., "USA", "Germany", "UK") is where we have observations
         - Use `places_with_data` to identify which place has observations
 
     * **For child entity sampling** like "population of Indian states":
@@ -420,11 +425,11 @@ async def search_indicators(
         - Results are indicative of broader child entity coverage
 
     * **For exploratory queries** like "what basic health data do you have":
-        - Call with `query="health"` and `mode="browse"` (or omit mode parameter)
+        - Call with `query="basic health"`
         - The tool will return organized topic categories and variables
 
     * **For non-place-constrained queries** like "what trade data do you have":
-        - Call with just the `query` parameter (automatically uses browse mode)
+        - Call with `query="trade"`
         - No place existence checks are performed
 
     Args:
@@ -479,42 +484,12 @@ async def search_indicators(
     - Both modes support place filtering and bilateral queries
     - Both modes use sophisticated query rewriting logic for optimal results
     """
-    # TODO: Phase 1 - Dummy response for manual testing
-    # Will implement business logic in Phase 2
-    
-    # Convert parameters to string representations for debugging
-    places_str = ",".join(places) if places else "None"
-    
-    return SearchResponse(
-        topics=[
-            SearchTopic(
-                dcid="dummy_topic_1",
-                member_topics=[],
-                member_variables=["dummy_var_1", "dummy_var_2"],
-                places_with_data=None
-            )
-        ],
-        variables=[
-            SearchVariable(
-                dcid="dummy_var_1",
-                places_with_data=["dummy_place_1"]
-            ),
-            SearchVariable(
-                dcid="dummy_var_2", 
-                places_with_data=["dummy_place_2"]
-            )
-        ],
-        dcid_name_mappings={
-            "dummy_topic_1": "DUMMY TOPIC - Phase 1 Testing",
-            "dummy_var_1": "DUMMY VARIABLE 1 - Phase 1 Testing",
-            "dummy_var_2": "DUMMY VARIABLE 2 - Phase 1 Testing",
-            "dummy_place_1": "DUMMY PLACE 1 - Phase 1 Testing",
-            "dummy_place_2": "DUMMY PLACE 2 - Phase 1 Testing",
-            # Tool parameters for debugging
-            "query": f'"{query}"',
-            "mode": f'"{mode}"',
-            "places": f'[{places_str}]',
-            "maybe_bilateral": str(maybe_bilateral),
-            "per_search_limit": str(per_search_limit)
-        }
+    # Call the real search_indicators service
+    return await search_indicators_service(
+        client=dc_client,
+        query=query,
+        mode=mode,
+        places=places,
+        maybe_bilateral=maybe_bilateral,
+        per_search_limit=per_search_limit,
     )

--- a/packages/datacommons-mcp/datacommons_mcp/server.py
+++ b/packages/datacommons-mcp/datacommons_mcp/server.py
@@ -446,7 +446,7 @@ async def search_indicators(
         **If `include_topics = False`**: Returns only variables
 
     **Processing the Response:**
-    * **Topics**: Collections of variables and sub-topics (browse mode only). Use the dcid_name_mappings to get readable names.
+    * **Topics**: Collections of variables and sub-topics. Use the dcid_name_mappings to get readable names.
     * **Variables**: Individual data indicators. Use the dcid_name_mappings to get readable names.
     * **places_with_data**: Only present when place filtering was performed. Shows which requested places have data for each indicator.
     * **Filter and rank**: Treat all results as candidates and filter/rank based on user context.

--- a/packages/datacommons-mcp/datacommons_mcp/services.py
+++ b/packages/datacommons-mcp/datacommons_mcp/services.py
@@ -126,22 +126,18 @@ async def search_indicators(
     query: str,
     mode: SearchModeType | None = None,
     places: list[str] | None = None,
-    bilateral_places: list[str] | None = None,
+    maybe_bilateral: bool = False,
     per_search_limit: int = 10,
 ) -> SearchResponse:
     """Search for topics and/or variables based on mode."""
     # Validate parameters and convert mode to enum
-    search_mode = _validate_search_parameters(
-        mode, places, bilateral_places, per_search_limit
-    )
+    search_mode = _validate_search_parameters(mode, per_search_limit)
 
     # Resolve place names to DCIDs
-    place_dcids_map = await _resolve_places(client, places, bilateral_places)
+    place_dcids_map = await _resolve_places(client, places)
 
     # Create search tasks based on place parameters
-    search_tasks = _create_search_tasks(
-        query, places, bilateral_places, place_dcids_map
-    )
+    search_tasks = _create_search_tasks(query, places, maybe_bilateral, place_dcids_map)
 
     search_result = await _search_indicators(
         client, search_mode, search_tasks, per_search_limit
@@ -165,15 +161,15 @@ async def search_indicators(
 def _create_search_tasks(
     query: str,
     places: list[str] | None,
-    bilateral_places: list[str] | None,
+    maybe_bilateral: bool,
     place_dcids_map: dict[str, str],
 ) -> list[SearchTask]:
     """Create search tasks based on place parameters.
 
     Args:
         query: The search query
-        places: List of place names (mutually exclusive with bilateral_places)
-        bilateral_places: List of exactly 2 place names (mutually exclusive with places)
+        places: List of place names
+        maybe_bilateral: Whether to include bilateral relationship searches
         place_dcids_map: Mapping of place names to DCIDs
 
     Returns:
@@ -181,45 +177,35 @@ def _create_search_tasks(
     """
     search_tasks = []
 
-    if places:
-        # Single search task with all place DCIDs (no query rewriting)
+    if places and maybe_bilateral:
+        # Place-specific searches first (one per place)
+        for place_name in places:
+            place_dcid = place_dcids_map.get(place_name)
+            if place_dcid:
+                # Include all DCIDs except the current place
+                other_place_dcids = [
+                    dcid
+                    for name, dcid in place_dcids_map.items()
+                    if name != place_name and dcid
+                ]
+                search_tasks.append(
+                    SearchTask(
+                        query=f"{query} {place_name}", place_dcids=other_place_dcids
+                    )
+                )
+
+        # Original query search last
         place_dcids = [
             place_dcids_map.get(name) for name in places if place_dcids_map.get(name)
         ]
         search_tasks.append(SearchTask(query=query, place_dcids=place_dcids))
 
-    elif bilateral_places:
-        # Three search tasks with query rewriting (same as current behavior)
-        place1_name, place2_name = bilateral_places
-        place1_dcid = place_dcids_map.get(place1_name)
-        place2_dcid = place_dcids_map.get(place2_name)
-
-        # Base query: search for the original query, filter by all available places
-        base_place_dcids = []
-        if place1_dcid:
-            base_place_dcids.append(place1_dcid)
-        if place2_dcid:
-            base_place_dcids.append(place2_dcid)
-
-        search_tasks.append(SearchTask(query=query, place_dcids=base_place_dcids))
-
-        # Place1 query: search for query + place1_name, filter by place2_dcid
-        if place1_dcid:
-            search_tasks.append(
-                SearchTask(
-                    query=f"{query} {place1_name}",
-                    place_dcids=[place2_dcid] if place2_dcid else [],
-                )
-            )
-
-        # Place2 query: search for query + place2_name, filter by place1_dcid
-        if place2_dcid:
-            search_tasks.append(
-                SearchTask(
-                    query=f"{query} {place2_name}",
-                    place_dcids=[place1_dcid] if place1_dcid else [],
-                )
-            )
+    elif places:
+        # Single search task with all place DCIDs (no query rewriting)
+        place_dcids = [
+            place_dcids_map.get(name) for name in places if place_dcids_map.get(name)
+        ]
+        search_tasks.append(SearchTask(query=query, place_dcids=place_dcids))
 
     else:
         # No places: single search task with no place constraints
@@ -230,16 +216,12 @@ def _create_search_tasks(
 
 def _validate_search_parameters(
     mode: SearchModeType | None,
-    places: list[str] | None,
-    bilateral_places: list[str] | None,
     per_search_limit: int,
 ) -> SearchMode:
     """Validate search parameters and convert mode to enum.
 
     Args:
         mode: Search mode string or None
-        places: List of place names (mutually exclusive with bilateral_places)
-        bilateral_places: List of exactly 2 place names (mutually exclusive with places)
         per_search_limit: Maximum results per search
 
     Returns:
@@ -263,27 +245,18 @@ def _validate_search_parameters(
     if not 1 <= per_search_limit <= 100:
         raise ValueError("per_search_limit must be between 1 and 100")
 
-    # Validate place parameters
-    if places is not None and bilateral_places is not None:
-        raise ValueError("Cannot specify both 'places' and 'bilateral_places'")
-
-    if bilateral_places is not None and len(bilateral_places) != 2:
-        raise ValueError("bilateral_places must contain exactly 2 place names")
-
     return search_mode
 
 
 async def _resolve_places(
     client: DCClient,
     places: list[str] | None,
-    bilateral_places: list[str] | None,
 ) -> dict[str, str]:
     """Resolve place names to DCIDs.
 
     Args:
         client: DCClient instance for place resolution
-        places: List of place names (mutually exclusive with bilateral_places)
-        bilateral_places: List of exactly 2 place names (mutually exclusive with places)
+        places: List of place names
 
     Returns:
         Dictionary mapping place names to DCIDs
@@ -291,13 +264,12 @@ async def _resolve_places(
     Raises:
         DataLookupError: If place resolution fails
     """
-    place_names = places or bilateral_places or []
 
-    if not place_names:
+    if not places:
         return {}
 
     try:
-        return await client.search_places(place_names)
+        return await client.search_places(places)
     except Exception as e:
         msg = "Error resolving place names"
         logger.error("%s: %s", msg, e)

--- a/packages/datacommons-mcp/datacommons_mcp/services.py
+++ b/packages/datacommons-mcp/datacommons_mcp/services.py
@@ -124,14 +124,14 @@ async def get_observations(
 async def search_indicators(
     client: DCClient,
     query: str,
-    mode: SearchModeType | None = None,
     places: list[str] | None = None,
+    include_topics: bool = True,
     maybe_bilateral: bool = False,
     per_search_limit: int = 10,
 ) -> SearchResponse:
-    """Search for topics and/or variables based on mode."""
-    # Validate parameters and convert mode to enum
-    search_mode = _validate_search_parameters(mode, per_search_limit)
+    """Search for topics and/or variables."""
+    # Validate parameters
+    _validate_search_parameters(per_search_limit)
 
     # Resolve place names to DCIDs
     place_dcids_map = await _resolve_places(client, places)
@@ -140,7 +140,10 @@ async def search_indicators(
     search_tasks = _create_search_tasks(query, places, maybe_bilateral, place_dcids_map)
 
     search_result = await _search_indicators(
-        client, search_mode, search_tasks, per_search_limit
+        client=client,
+        include_topics=include_topics,
+        search_tasks=search_tasks,
+        per_search_limit=per_search_limit,
     )
 
     # Collect all DCIDs for lookups
@@ -210,37 +213,19 @@ def _create_search_tasks(
 
 
 def _validate_search_parameters(
-    mode: SearchModeType | None,
     per_search_limit: int,
-) -> SearchMode:
-    """Validate search parameters and convert mode to enum.
+) -> None:
+    """Validate search parameters
 
     Args:
-        mode: Search mode string or None
         per_search_limit: Maximum results per search
-
-    Returns:
-        SearchMode enum value
 
     Raises:
         ValueError: If any parameter validation fails
     """
-    # Convert string mode to enum for validation and comparison, defaulting to browse if not specified
-    if not mode:
-        search_mode = SearchMode.BROWSE
-    else:
-        try:
-            search_mode = SearchMode(mode)
-        except ValueError as e:
-            raise ValueError(
-                f"mode must be either '{SearchMode.BROWSE.value}' or '{SearchMode.LOOKUP.value}'"
-            ) from e
-
     # Validate per_search_limit parameter
     if not 1 <= per_search_limit <= 100:
         raise ValueError("per_search_limit must be between 1 and 100")
-
-    return search_mode
 
 
 async def _resolve_places(
@@ -303,8 +288,8 @@ def _collect_all_dcids(
 
 async def _search_indicators(
     client: DCClient,
-    mode: SearchMode,
     search_tasks: list[SearchTask],
+    include_topics: bool,
     per_search_limit: int = 10,
 ) -> SearchResult:
     """Search for indicators matching a query, optionally filtered by place existence.
@@ -317,8 +302,8 @@ async def _search_indicators(
     for search_task in search_tasks:
         task = client.fetch_indicators(
             query=search_task.query,
-            mode=mode,
             place_dcids=search_task.place_dcids,
+            include_topics=include_topics,
             max_results=per_search_limit,
         )
         tasks.append(task)

--- a/packages/datacommons-mcp/datacommons_mcp/services.py
+++ b/packages/datacommons-mcp/datacommons_mcp/services.py
@@ -176,22 +176,20 @@ def _create_search_tasks(
         List of SearchTask objects
     """
     search_tasks = []
+    place_dcids = (
+        [place_dcids_map.get(name) for name in places if place_dcids_map.get(name)]
+        if places and place_dcids_map
+        else []
+    )
 
     if places and maybe_bilateral:
         # Place-specific searches first (one per place)
         for place_name in places:
             place_dcid = place_dcids_map.get(place_name)
             if place_dcid:
-                # Include all DCIDs except the current place
-                other_place_dcids = [
-                    dcid
-                    for name, dcid in place_dcids_map.items()
-                    if name != place_name and dcid
-                ]
+                # Rewrite query to include place name and include all place DCIDs
                 search_tasks.append(
-                    SearchTask(
-                        query=f"{query} {place_name}", place_dcids=other_place_dcids
-                    )
+                    SearchTask(query=f"{query} {place_name}", place_dcids=place_dcids)
                 )
 
         # Original query search last
@@ -202,9 +200,6 @@ def _create_search_tasks(
 
     elif places:
         # Single search task with all place DCIDs (no query rewriting)
-        place_dcids = [
-            place_dcids_map.get(name) for name in places if place_dcids_map.get(name)
-        ]
         search_tasks.append(SearchTask(query=query, place_dcids=place_dcids))
 
     else:

--- a/packages/datacommons-mcp/tests/test_dc_client.py
+++ b/packages/datacommons-mcp/tests/test_dc_client.py
@@ -28,7 +28,6 @@ import pytest
 from datacommons_client.client import DataCommonsClient
 from datacommons_mcp.clients import DCClient, create_dc_client
 from datacommons_mcp.data_models.enums import SearchScope
-from datacommons_mcp.data_models.search import SearchMode
 from datacommons_mcp.data_models.observations import (
     DateRange,
     ObservationApiResponse,
@@ -462,7 +461,9 @@ class TestDCClientFetchIndicators:
     """Tests for the fetch_indicators method of DCClient."""
 
     @pytest.mark.asyncio
-    async def test_fetch_indicators_browse_mode_basic(self, mocked_datacommons_client):
+    async def test_fetch_indicators_include_topics_true(
+        self, mocked_datacommons_client
+    ):
         """Test basic functionality without place filtering."""
         # Arrange: Create client and mock search results
         client_under_test = DCClient(dc=mocked_datacommons_client)
@@ -501,7 +502,7 @@ class TestDCClientFetchIndicators:
 
         # Act: Call the method
         result = await client_under_test.fetch_indicators(
-            "test query", mode=SearchMode.BROWSE
+            "test query", include_topics=True
         )
 
         # Assert: Verify the response structure
@@ -527,7 +528,9 @@ class TestDCClientFetchIndicators:
         assert result["lookups"]["dc/variable/Count_Person"] == "Count of Persons"
 
     @pytest.mark.asyncio
-    async def test_fetch_indicators_lookup_mode_basic(self, mocked_datacommons_client):
+    async def test_fetch_indicators_include_topics_false(
+        self, mocked_datacommons_client
+    ):
         """Test basic functionality without place filtering."""
         # Arrange: Create client and mock search results
         client_under_test = DCClient(dc=mocked_datacommons_client)
@@ -535,8 +538,6 @@ class TestDCClientFetchIndicators:
         # Mock search_svs to return topics and variables
         mock_search_results = {
             "test query": [
-                {"SV": "dc/topic/Health", "CosineScore": 0.9},
-                {"SV": "dc/topic/Economy", "CosineScore": 0.8},
                 {"SV": "dc/variable/Count_Person", "CosineScore": 0.7},
                 {"SV": "dc/variable/Count_Household", "CosineScore": 0.6},
             ]
@@ -555,23 +556,15 @@ class TestDCClientFetchIndicators:
         }.get(dcid, dcid)
 
         # Mock topic data
-        client_under_test.topic_store.topics_by_dcid = {
-            "dc/topic/Health": Mock(
-                member_topics=[], variables=["dc/variable/Count_Person"]
-            ),
-            "dc/topic/Economy": Mock(
-                member_topics=[], variables=["dc/variable/Count_Household"]
-            ),
-        }
+        client_under_test.topic_store.topics_by_dcid = {}
 
-        client_under_test.topic_store.get_topic_variables.side_effect = lambda dcid: {
-            "dc/topic/Health": ["dc/variable/Count_Health"],
-            "dc/topic/Economy": ["dc/variable/Count_Economy"],
-        }.get(dcid, [])
+        client_under_test.topic_store.get_topic_variables.side_effect = (
+            lambda dcid: {}.get(dcid, [])
+        )
 
         # Act: Call the method
         result = await client_under_test.fetch_indicators(
-            "test query", mode=SearchMode.LOOKUP
+            "test query", include_topics=False
         )
 
         # Assert: Verify the response structure
@@ -583,22 +576,20 @@ class TestDCClientFetchIndicators:
         assert len(result["topics"]) == 0
 
         # Verify variables
-        assert len(result["variables"]) == 4
+        assert len(result["variables"]) == 2
         variable_dcids = [var["dcid"] for var in result["variables"]]
         assert variable_dcids == [
-            "dc/variable/Count_Health",
-            "dc/variable/Count_Economy",
             "dc/variable/Count_Person",
             "dc/variable/Count_Household",
         ]
 
         # Verify lookups
-        assert len(result["lookups"]) == 4
-        assert result["lookups"]["dc/variable/Count_Health"] == "Count of Health"
+        assert len(result["lookups"]) == 2
+        assert result["lookups"]["dc/variable/Count_Household"] == "Count of Households"
         assert result["lookups"]["dc/variable/Count_Person"] == "Count of Persons"
 
     @pytest.mark.asyncio
-    async def test_fetch_indicators_browse_mode_with_places(
+    async def test_fetch_indicators_include_topics_with_places(
         self, mocked_datacommons_client
     ):
         """Test functionality with place filtering."""
@@ -640,7 +631,7 @@ class TestDCClientFetchIndicators:
 
         # Act: Call the method with place filtering
         result = await client_under_test.fetch_indicators(
-            "test query", mode=SearchMode.BROWSE, place_dcids=["geoId/06", "geoId/36"]
+            "test query", place_dcids=["geoId/06", "geoId/36"], include_topics=True
         )
 
         # Assert: Verify that only variables with data are returned
@@ -776,7 +767,7 @@ class TestDCClientFetchIndicators:
 
         # Act: Call the method
         result = await client_under_test._search_indicators(
-            "test query", mode=SearchMode.BROWSE
+            "test query", include_topics=True
         )
 
         # Assert: Verify that only valid topics are returned
@@ -817,7 +808,7 @@ class TestDCClientFetchIndicators:
 
         # Act: Call the method
         result = await client_under_test._search_indicators(
-            "test query", mode=SearchMode.BROWSE
+            "test query", include_topics=True
         )
 
         # Assert: Verify that no topics are returned when topic store is None
@@ -848,7 +839,7 @@ class TestDCClientFetchIndicators:
         client_under_test.search_svs = AsyncMock(return_value=mock_search_results)
 
         result = await client_under_test._search_indicators(
-            "test query", mode=SearchMode.BROWSE, max_results=2
+            "test query", include_topics=True, max_results=2
         )
 
         # Verify that search_svs was called with max_results=2

--- a/packages/datacommons-mcp/tests/test_services.py
+++ b/packages/datacommons-mcp/tests/test_services.py
@@ -374,7 +374,8 @@ class TestSearchIndicators:
             client=mock_client,
             query="trade",
             mode="lookup",
-            bilateral_places=["France", "Germany"],
+            places=["France", "Germany"],
+            maybe_bilateral=True,
         )
 
         # Should have deduplicated variables in expected order
@@ -535,8 +536,8 @@ class TestSearchIndicators:
         )
 
     @pytest.mark.asyncio
-    async def test_search_indicators_bilateral_places_behavior(self):
-        """Test bilateral_places parameter behavior across browse and lookup modes."""
+    async def test_search_indicators_maybe_bilateral_behavior(self):
+        """Test maybe_bilateral parameter behavior across browse and lookup modes."""
         mock_client = Mock()
         mock_client.search_places = AsyncMock(
             return_value={"USA": "country/USA", "France": "country/FRA"}
@@ -544,12 +545,13 @@ class TestSearchIndicators:
         mock_client.fetch_indicators = AsyncMock(return_value={})
         mock_client.fetch_entity_names = Mock(return_value={})
 
-        # Test 1: Bilateral places in browse mode
+        # Test 1: Maybe bilateral in browse mode
         result = await search_indicators(
             client=mock_client,
             query="trade exports",
             mode="browse",
-            bilateral_places=["USA", "France"],
+            places=["USA", "France"],
+            maybe_bilateral=True,
         )
         assert result.status == "SUCCESS"
         mock_client.search_places.assert_called_with(["USA", "France"])
@@ -557,25 +559,25 @@ class TestSearchIndicators:
 
         # Assert the actual queries fetch_indicators was called with
         calls = mock_client.fetch_indicators.call_args_list
-        # The first call should be just the base query with both place DCIDs
+        # The first call should be with USA appended to query, filtered by France
         assert calls[0].kwargs == {
-            "query": "trade exports",
-            "mode": SearchMode.BROWSE,
-            "place_dcids": ["country/USA", "country/FRA"],
-            "max_results": 10,
-        }
-        # The second call should be with USA appended to query, filtered by France
-        assert calls[1].kwargs == {
             "query": "trade exports USA",
             "mode": SearchMode.BROWSE,
             "place_dcids": ["country/FRA"],
             "max_results": 10,
         }
-        # The third call should be with France appended to query, filtered by USA
-        assert calls[2].kwargs == {
+        # The second call should be with France appended to query, filtered by USA
+        assert calls[1].kwargs == {
             "query": "trade exports France",
             "mode": SearchMode.BROWSE,
             "place_dcids": ["country/USA"],
+            "max_results": 10,
+        }
+        # The third call should be the original query with both place DCIDs
+        assert calls[2].kwargs == {
+            "query": "trade exports",
+            "mode": SearchMode.BROWSE,
+            "place_dcids": ["country/USA", "country/FRA"],
             "max_results": 10,
         }
 
@@ -587,12 +589,13 @@ class TestSearchIndicators:
         mock_client.fetch_indicators = AsyncMock(return_value={})
         mock_client.fetch_entity_names = Mock(return_value={})
 
-        # Test 2: Bilateral places in lookup mode
+        # Test 2: Maybe bilateral in lookup mode
         result = await search_indicators(
             client=mock_client,
             query="trade exports",
             mode="lookup",
-            bilateral_places=["USA", "France"],
+            places=["USA", "France"],
+            maybe_bilateral=True,
         )
         assert result.status == "SUCCESS"
         mock_client.search_places.assert_called_with(["USA", "France"])
@@ -600,25 +603,25 @@ class TestSearchIndicators:
 
         # Assert the same query rewriting behavior
         calls = mock_client.fetch_indicators.call_args_list
-        # The first call should be just the base query with both place DCIDs
+        # The first call should be with USA appended to query, filtered by France
         assert calls[0].kwargs == {
-            "query": "trade exports",
-            "mode": SearchMode.LOOKUP,
-            "place_dcids": ["country/USA", "country/FRA"],
-            "max_results": 10,
-        }
-        # The second call should be with USA appended to query, filtered by France
-        assert calls[1].kwargs == {
             "query": "trade exports USA",
             "mode": SearchMode.LOOKUP,
             "place_dcids": ["country/FRA"],
             "max_results": 10,
         }
-        # The third call should be with France appended to query, filtered by USA
-        assert calls[2].kwargs == {
+        # The second call should be with France appended to query, filtered by USA
+        assert calls[1].kwargs == {
             "query": "trade exports France",
             "mode": SearchMode.LOOKUP,
             "place_dcids": ["country/USA"],
+            "max_results": 10,
+        }
+        # The third call should be the original query with both place DCIDs
+        assert calls[2].kwargs == {
+            "query": "trade exports",
+            "mode": SearchMode.LOOKUP,
+            "place_dcids": ["country/USA", "country/FRA"],
             "max_results": 10,
         }
 
@@ -632,35 +635,32 @@ class TestSearchIndicators:
         mock_client.fetch_indicators = AsyncMock(return_value={"variables": []})
         mock_client.fetch_entity_names = Mock(return_value={})
 
-        # Test both places and bilateral_places specified (should raise ValueError)
-        with pytest.raises(
-            ValueError, match="Cannot specify both 'places' and 'bilateral_places'"
-        ):
-            await search_indicators(
-                client=mock_client,
-                query="test",
-                places=["USA"],
-                bilateral_places=["USA", "France"],
-            )
+        # Test maybe_bilateral=True with places (should work)
+        result = await search_indicators(
+            client=mock_client,
+            query="test",
+            places=["USA", "France"],
+            maybe_bilateral=True,
+        )
+        assert result.status == "SUCCESS"
+        assert mock_client.fetch_indicators.call_count == 3  # len(places) + 1
 
-        # Test bilateral_places with != 2 items (should raise ValueError)
-        with pytest.raises(
-            ValueError, match="bilateral_places must contain exactly 2 place names"
-        ):
-            await search_indicators(
-                client=mock_client,
-                query="test",
-                bilateral_places=["USA"],  # Only 1 place
-            )
+        # Test maybe_bilateral=False with places (should work)
+        mock_client.reset_mock()
+        mock_client.search_places = AsyncMock(
+            return_value={"USA": "country/USA", "France": "country/FRA"}
+        )
+        mock_client.fetch_indicators = AsyncMock(return_value={"variables": []})
+        mock_client.fetch_entity_names = Mock(return_value={})
 
-        with pytest.raises(
-            ValueError, match="bilateral_places must contain exactly 2 place names"
-        ):
-            await search_indicators(
-                client=mock_client,
-                query="test",
-                bilateral_places=["USA", "France", "Germany"],  # 3 places
-            )
+        result = await search_indicators(
+            client=mock_client,
+            query="test",
+            places=["USA", "France"],
+            maybe_bilateral=False,
+        )
+        assert result.status == "SUCCESS"
+        assert mock_client.fetch_indicators.call_count == 1  # single search
 
         # Test valid combinations (should not raise)
         # Single place
@@ -679,11 +679,12 @@ class TestSearchIndicators:
         )
         assert result.status == "SUCCESS"
 
-        # Bilateral places
+        # Maybe bilateral with places
         result = await search_indicators(
             client=mock_client,
             query="test",
-            bilateral_places=["USA", "France"],
+            places=["USA", "France"],
+            maybe_bilateral=True,
         )
         assert result.status == "SUCCESS"
 

--- a/packages/datacommons-mcp/tests/test_services.py
+++ b/packages/datacommons-mcp/tests/test_services.py
@@ -559,18 +559,18 @@ class TestSearchIndicators:
 
         # Assert the actual queries fetch_indicators was called with
         calls = mock_client.fetch_indicators.call_args_list
-        # The first call should be with USA appended to query, filtered by France
+        # The first call should be with USA appended to query
         assert calls[0].kwargs == {
             "query": "trade exports USA",
             "mode": SearchMode.BROWSE,
-            "place_dcids": ["country/FRA"],
+            "place_dcids": ["country/USA", "country/FRA"],
             "max_results": 10,
         }
-        # The second call should be with France appended to query, filtered by USA
+        # The second call should be with France appended to query
         assert calls[1].kwargs == {
             "query": "trade exports France",
             "mode": SearchMode.BROWSE,
-            "place_dcids": ["country/USA"],
+            "place_dcids": ["country/USA", "country/FRA"],
             "max_results": 10,
         }
         # The third call should be the original query with both place DCIDs
@@ -603,18 +603,18 @@ class TestSearchIndicators:
 
         # Assert the same query rewriting behavior
         calls = mock_client.fetch_indicators.call_args_list
-        # The first call should be with USA appended to query, filtered by France
+        # The first call should be with USA appended to query
         assert calls[0].kwargs == {
             "query": "trade exports USA",
             "mode": SearchMode.LOOKUP,
-            "place_dcids": ["country/FRA"],
+            "place_dcids": ["country/USA", "country/FRA"],
             "max_results": 10,
         }
-        # The second call should be with France appended to query, filtered by USA
+        # The second call should be with France appended to query
         assert calls[1].kwargs == {
             "query": "trade exports France",
             "mode": SearchMode.LOOKUP,
-            "place_dcids": ["country/USA"],
+            "place_dcids": ["country/USA", "country/FRA"],
             "max_results": 10,
         }
         # The third call should be the original query with both place DCIDs


### PR DESCRIPTION
This PR is stacked on top of PR #41. It should be rebased once #41 is merged. The differences between this PR and the code on PR #41 can be [viewed here](https://github.com/keyurva/dcagent-toolkit/compare/maybe-bilateral...ONEcampaign:agent-toolkit:remove-mode). 

This PR follows up on [this comment](https://github.com/datacommonsorg/agent-toolkit/pull/41#pullrequestreview-3197573891). It removes the 'mode' parameter in favour of an 'include_topics' boolean. 

The PR updates functions, the tool instructions, and tests accordingly.