### PR TITLE
Update tool instructions for include_topics and places

### DIFF
--- a/packages/datacommons-mcp/datacommons_mcp/server.py
+++ b/packages/datacommons-mcp/datacommons_mcp/server.py
@@ -401,7 +401,7 @@ async def search_indicators(
     **places Parameter Guidelines:**
 
     Always use the human-readable place names in English (e.g., 'California', 'Canada'),
-    not their DCIDs (e.g., 'geoId/06', 'country/CAN' or 'wikidataId/Q1979').
+    not their DCIDs (e.g., 'geoId/06', 'country/CAN', or 'wikidataId/Q1979').
     If you obtain place information from another tool, ensure you extract and use place names only for search_indicators.
 
     * **For place-constrained queries** like "population of France":


### PR DESCRIPTION
* `include_topics`
   + Fixed a bug where this parameter was not passed to the services layer
   + Documented guidelines for the `include_topics` parameter
   + Tested it against a test client with ONE's custom DC that explicitly prompted the agent to always use `include_topics = True` (the ONE use case) which it followed correctly
   + Tested with another client against base DC without explicit instructions and it used the parameter based on the nature of the query

* `places`
   + Added instructions to never use DCIDs and at least in my test agent it followed the instructions correctly. In previous sessions with the same agent prior the instruction change, it did call it with DCIDs once in a while.
   + Added instructions for when the place results did not match the user's intent and it followed it correctly (see screenshot below)

### Example of agent auto-correcting when initial place results did not match the query's intent

<img width="1973" height="1226" alt="image" src="https://github.com/user-attachments/assets/0ed4fe7a-4ae6-4292-b2bb-6aa3967b8cbb" />
