### PR TITLE
Make MCP server stateless

### DIFF
--- a/packages/datacommons-mcp/datacommons_mcp/server.py
+++ b/packages/datacommons-mcp/datacommons_mcp/server.py
@@ -62,7 +62,10 @@ except Exception as e:
     logger.error("Failed to create DC client: %s", e)
     raise
 
-mcp = FastMCP("DC MCP Server")
+mcp = FastMCP(
+    "DC MCP Server",
+    stateless_http=True,
+)
 
 
 @mcp.tool()


### PR DESCRIPTION
Currently the MCP server is started in stateful mode (the default mode), which requires clients to manage session id's to interact with the server. I was hitting some issues with this when testing out deployment (on cloud run), and disabling it solved those issues. I think because it requires traffic to be routed to the exact same instance. 

Since nothing is stateful about the MCP interactions, marking it as stateless simplifies those session, and existing clients should work just fine with that change. 