### PR TITLE
Add dateutil to mcp dependencies

### DIFF
--- a/packages/datacommons-mcp/pyproject.toml
+++ b/packages/datacommons-mcp/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "datacommons-client",
     "pydantic>=2.11.7",
     "pydantic-settings",
+    "python-dateutil>=2.9.0.post0",
 ]
 urls = {Homepage = "https://github.com/datacommonsorg/agent-toolkit"}
 

--- a/uv.lock
+++ b/uv.lock
@@ -385,6 +385,7 @@ dependencies = [
     { name = "fastmcp" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "python-dateutil" },
     { name = "requests" },
     { name = "uvicorn" },
 ]
@@ -396,6 +397,7 @@ requires-dist = [
     { name = "fastmcp" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pydantic-settings" },
+    { name = "python-dateutil", specifier = ">=2.9.0.post0" },
     { name = "requests" },
     { name = "uvicorn" },
 ]


### PR DESCRIPTION
Deploying the MCP server to Cloud Run fails following the merge of #36. 
`python-dateutil` must be in the `pyproject.toml` file of the `datecommons-mcp` server for dependencies to resolve correctly ([used here](https://github.com/datacommonsorg/agent-toolkit/pull/36/files#diff-8846a4a883607d5802c71966caacacaeb2af7a8108c8e80af2ec1814df485df3R28)). 