### PR TITLE
Remove place_name parameter from get_observations

### DIFF
--- a/packages/datacommons-test-agents/datacommons_test_agents/basic_agent/evals/data/get_observations/date_params.test.json
+++ b/packages/datacommons-test-agents/datacommons_test_agents/basic_agent/evals/data/get_observations/date_params.test.json
@@ -6,7 +6,7 @@
         "tool_name": "get_observations",
         "tool_input": {
           "date": "latest",
-          "place_name": "California",
+          "place_dcid": "geoId/06",
           "variable_dcid": "Count_Person"
         }
       }
@@ -20,7 +20,7 @@
         "tool_name": "get_observations",
         "tool_input": {
           "date": "2023",
-          "place_name": "California",
+          "place_dcid": "geoId/06",
           "variable_dcid": "Count_Person"
         }
       }
@@ -36,7 +36,7 @@
           "date": "range",
           "date_range_start": "2002-05",
           "date_range_end": "2005-11",
-          "place_name": "California",
+          "place_dcid": "geoId/06",
           "variable_dcid": "Count_Person"
         }
       }
@@ -50,7 +50,7 @@
         "tool_name": "get_observations",
         "tool_input": {
           "date": "all",
-          "place_name": "California",
+          "place_dcid": "geoId/06",
           "variable_dcid": "Count_Person"
         }
       }

--- a/packages/datacommons-test-agents/datacommons_test_agents/basic_agent/evals/data/get_observations/place_params.test.json
+++ b/packages/datacommons-test-agents/datacommons_test_agents/basic_agent/evals/data/get_observations/place_params.test.json
@@ -6,7 +6,7 @@
                 "tool_name": "get_observations",
                 "tool_input": {
                     "date": "latest",
-                    "place_name": "India",
+                    "place_dcid": "country/IND",
                     "variable_dcid": "Count_Person"
                 }
             }
@@ -20,7 +20,7 @@
                 "tool_name": "get_observations",
                 "tool_input": {
                     "date": "latest",
-                    "place_name": "India",
+                    "place_dcid": "country/IND",
                     "variable_dcid": "Count_Person",
                     "child_place_type": "AdministrativeArea1"
                 }
@@ -35,7 +35,7 @@
                 "tool_name": "get_observations",
                 "tool_input": {
                     "date": "all",
-                    "place_name": "Uttar Pradesh",
+                    "place_dcid": "wikidataId/Q1498",
                     "variable_dcid": "Count_Person"
                 }
             },
@@ -43,7 +43,7 @@
                 "tool_name": "get_observations",
                 "tool_input": {
                     "date": "all",
-                    "place_name": "Maharashtra",
+                    "place_dcid": "wikidataId/Q1191",
                     "variable_dcid": "Count_Person"
                 }
             }

--- a/packages/datacommons-test-agents/datacommons_test_agents/basic_agent/evals/data/get_observations/source_params.test.json
+++ b/packages/datacommons-test-agents/datacommons_test_agents/basic_agent/evals/data/get_observations/source_params.test.json
@@ -6,7 +6,7 @@
                 "tool_name": "get_observations",
                 "tool_input": {
                     "date": "latest",
-                    "place_name": "India",
+                    "place_dcid": "country/IND",
                     "variable_dcid": "Count_Person",
                     "child_place_type": "AdministrativeArea1"
                 }
@@ -21,7 +21,7 @@
                 "tool_name": "get_observations",
                 "tool_input": {
                     "date": "latest",
-                    "place_name": "India",
+                    "place_dcid": "country/IND",
                     "variable_dcid": "Count_Person",
                     "child_place_type": "AdministrativeArea1",
                     "source_override": "2123271870"


### PR DESCRIPTION
* Removing `place_name` parameter nudges the agent to fetch `place_dcid` from search_indicators
* This coupled with instruction changes makes it explicitly fetch indicators for a place instead of reusing indicators it may have fetched for other places earlier in the session
* This change does not address the issue where agents sometimes call `search_indicators` for the parent place even though query asks for child places
   - e.g. "population of indian states" sometimes calls search indicators with "India" instead of a sampling of Indian states
   - this requires updates to the `search_indicators` tool which we'll do in a separate PR
* I've intentionally not updated the services layer to keep this PR scoped to just the tool change. Will do that separately.

### Example of what this fixes

<img width="2848" height="2064" alt="image" src="https://github.com/user-attachments/assets/0ef45127-190c-4fce-bea8-0bfa515c1294" />
