### PR TITLE
Fix `_parse_list_like_parameter` issue when parsing lists

### DIFF
--- a/packages/datacommons-mcp/datacommons_mcp/data_models/settings.py
+++ b/packages/datacommons-mcp/datacommons_mcp/data_models/settings.py
@@ -142,12 +142,14 @@ class CustomDCSettings(BaseSettings):
 
 def _parse_list_like_parameter(v: Any) -> list[str] | None:  # noqa: ANN401
     """Parse comma-separated string into list of strings."""
+    if isinstance(v, list):
+        return v
     if not isinstance(v, str) or not v.strip():
         return None
-    # Split by comma and strip whitespace from each item
-    items = [item.strip() for item in v.split(",")]
+    # Split by comma and strip whitespace from each item, filtering out empty strings
+    items = [s for s in (part.strip() for part in v.split(",")) if s]
     # Filter out empty items
-    return [item for item in items if item]
+    return items
 
 
 # Union type for both settings

--- a/packages/datacommons-mcp/datacommons_mcp/data_models/settings.py
+++ b/packages/datacommons-mcp/datacommons_mcp/data_models/settings.py
@@ -141,7 +141,7 @@ class CustomDCSettings(BaseSettings):
 
 
 def _parse_list_like_parameter(v: Any) -> list[str] | None:  # noqa: ANN401
-     """Parse a comma-separated string or a list into a list of strings."""
+    """Parse a comma-separated string or a list into a list of strings."""
     if isinstance(v, list):
         return [s for s in (str(item).strip() for item in v) if s]
     if not isinstance(v, str) or not v.strip():

--- a/packages/datacommons-mcp/datacommons_mcp/data_models/settings.py
+++ b/packages/datacommons-mcp/datacommons_mcp/data_models/settings.py
@@ -143,13 +143,11 @@ class CustomDCSettings(BaseSettings):
 def _parse_list_like_parameter(v: Any) -> list[str] | None:  # noqa: ANN401
     """Parse comma-separated string into list of strings."""
     if isinstance(v, list):
-        return v
+        return [s for s in (str(item).strip() for item in v) if s]
     if not isinstance(v, str) or not v.strip():
         return None
     # Split by comma and strip whitespace from each item, filtering out empty strings
-    items = [s for s in (part.strip() for part in v.split(",")) if s]
-    # Filter out empty items
-    return items
+    return [s for s in (part.strip() for part in v.split(",")) if s]
 
 
 # Union type for both settings

--- a/packages/datacommons-mcp/datacommons_mcp/data_models/settings.py
+++ b/packages/datacommons-mcp/datacommons_mcp/data_models/settings.py
@@ -141,7 +141,7 @@ class CustomDCSettings(BaseSettings):
 
 
 def _parse_list_like_parameter(v: Any) -> list[str] | None:  # noqa: ANN401
-    """Parse comma-separated string into list of strings."""
+     """Parse a comma-separated string or a list into a list of strings."""
     if isinstance(v, list):
         return [s for s in (str(item).strip() for item in v) if s]
     if not isinstance(v, str) or not v.strip():


### PR DESCRIPTION
This PR fixes an issue with the new `_parse_list_like_parameter` utility function in `settings.py` by handling cases where the input is already a list.

I also simplified the process of removing empty (or empty with strings) process slightly.

This relates to changes introduced by #56, as mentioned in https://github.com/datacommonsorg/agent-toolkit/pull/56#discussion_r2351065979