### PR TITLE
Remove DC_TOPIC_CACHE_PATHS from .env.sample

### DIFF
--- a/packages/datacommons-mcp/.env.sample
+++ b/packages/datacommons-mcp/.env.sample
@@ -58,11 +58,3 @@ DC_TYPE=base
 # Search base URL for base Data Commons (optional, base DC only)
 # Default: "https://datacommons.org"
 # DC_SV_SEARCH_BASE_URL=https://datacommons.org
-
-# =============================================================================
-# ADVANCED TOPIC CONFIGURATION (optional)
-# =============================================================================
-
-# Paths to topic cache files (optional, base DC only)
-# Used for caching topic data to avoid repeated API calls
-# DC_TOPIC_CACHE_PATHS=./data/topics/topic_cache.json,./data/topics/sdg_topic_cache.json


### PR DESCRIPTION
* The `DC_TOPIC_CACHE_PATHS` env var is almost never used
* In the rare event it is, it is only be used by a DC team developer experimenting with different topic caches
* In light of this, we are removing this from the sample env file to avoid confusion