### PR TITLE
Remove advanced config

### DIFF
--- a/packages/datacommons-mcp/.env.sample
+++ b/packages/datacommons-mcp/.env.sample
@@ -42,19 +42,3 @@ DC_TYPE=base
 # Options: "base_only", "custom_only", "base_and_custom"
 # Default: "base_and_custom" for custom DC
 # DC_SEARCH_SCOPE=base_and_custom
-
-# =============================================================================
-# ADVANCED SEARCH CONFIGURATION (optional)
-# =============================================================================
-
-# Search index for base Data Commons (optional)
-# Default: "base_uae_mem" for base DC, "medium_ft" for custom DC
-# DC_BASE_INDEX=medium_ft
-
-# Search index for custom Data Commons (optional, custom DC only)
-# Default: "user_all_minilm_mem"
-# DC_CUSTOM_INDEX=user_all_minilm_mem
-
-# Search base URL for base Data Commons (optional, base DC only)
-# Default: "https://datacommons.org"
-# DC_SV_SEARCH_BASE_URL=https://datacommons.org

--- a/packages/datacommons-mcp/docs/dev.md
+++ b/packages/datacommons-mcp/docs/dev.md
@@ -115,22 +115,12 @@ To setup:
 
 ### DC client configuration
 
-The server uses configuration from [config.py](config.py) which supports:
+The server uses configuration from environment variables or a `.env` file. 
 
-- Base Data Commons instance
-- Custom Data Commons instance
+- See [.env.sample](../.env.sample) for frequently used parameters and example configuration
+- See [data_models/settings.py](../datacommons_mcp/data_models/settings.py) for all available configuration parameters
 
-Instantiate the clients in [server.py](server.py) based on the configuration.
-
-> **TODO**: Configuration will soon be changed from hardcoded config in code to configuration via environment variables for better deployment flexibility.
-
-```python
-# Base DC client only
-dc_client = create_dc_client(config.BASE_DC_CONFIG)
-
-# Custom DC client (includes base + custom search capabilities)
-dc_client = create_dc_client(config.CUSTOM_DC_CONFIG)
-```
+Create a `.env` file in the project root with your configuration.
 
 ### File Checks + Formatting
 ```bash


### PR DESCRIPTION
* The advanced config is something only internal developers would use fleetingly for dev purposes
* Removing them from the env sample file to simplify the config and avoid confusion
* Thanks @kmoscoe for rightfully questioning this config - it's gone now!