### PR TITLE
removed hello command line group

### DIFF
--- a/packages/datacommons-mcp/datacommons_mcp/cli.py
+++ b/packages/datacommons-mcp/datacommons_mcp/cli.py
@@ -10,12 +10,6 @@ def cli() -> None:
     logging.basicConfig(level=logging.INFO)
 
 
-@cli.command()
-def hello() -> None:
-    """Print a hello message."""
-    click.echo("Hello from datacommons-mcp CLI!")
-
-
 @cli.group()
 def serve() -> None:
     """Serve the MCP server in different modes."""


### PR DESCRIPTION
Before:

```
$ uvx datacommons-mcp 
Installed 65 packages in 97ms
Usage: datacommons-mcp [OPTIONS] COMMAND [ARGS]...

  DataCommons MCP CLI - Model Context Protocol server for Data Commons.

Options:
  --help  Show this message and exit.

Commands:
  hello  Print a hello message.
  serve  Serve the MCP server in different modes.
```

After:

```
$ uv run datacommons-mcp
Usage: datacommons-mcp [OPTIONS] COMMAND [ARGS]...

  DataCommons MCP CLI - Model Context Protocol server for Data Commons.

Options:
  --help  Show this message and exit.

Commands:
  serve  Serve the MCP server in different modes.
```