### PR TITLE
Updated github ci test and evals to only run if there are relevant code changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,9 +4,17 @@ on:
   pull_request:
     branches:
       - main
+    # Run CI checks when code in the datacommons-mcp package changes.
+    paths:
+      - "packages/datacommons-mcp/datacommons_mcp/**"
+      - "packages/datacommons-mcp/tests/**"
   push:
     branches:
       - main
+    # Run CI checks when code in the datacommons-mcp package changes.
+    paths:
+      - "packages/datacommons-mcp/datacommons_mcp/**"
+      - "packages/datacommons-mcp/tests/**"
 
 jobs:
   ci-checks:

--- a/.github/workflows/evals.yaml
+++ b/.github/workflows/evals.yaml
@@ -7,6 +7,10 @@ on:
   pull_request_target:
     branches:
       - main
+    # Run evals when code in the datacommons-mcp package changes.
+    paths:
+      - "packages/datacommons-mcp/datacommons_mcp/**"
+      - "packages/datacommons-mcp/evals/**"
 
   # Allows maintainers to manually re-run evals on a specific PR number.
   workflow_dispatch:


### PR DESCRIPTION
Now unit tests will only run with changes to these directories:
      - "packages/datacommons-mcp/datacommons_mcp/**"
      - "packages/datacommons-mcp/tests/**"

Evals will run with changes to:
      - "packages/datacommons-mcp/datacommons_mcp/**"
      - "packages/datacommons-mcp/evals/**"

This should take effect after this PR is merged