### PR TITLE
Eliminate validate_child_place_types tool and enhance place name qualification

### DIFF
--- a/packages/datacommons-mcp/datacommons_mcp/clients.py
+++ b/packages/datacommons-mcp/datacommons_mcp/clients.py
@@ -171,7 +171,7 @@ class DCClient:
             type_dcids = response.extract_connected_dcids(dcid, "typeOf")
 
             if name_nodes and type_dcids:
-                result[dcid] = NodeInfo(name=name_nodes[0].value, typeOf=type_dcids)
+                result[dcid] = NodeInfo(name=name_nodes[0].value, type_of=type_dcids)
 
         return result
 

--- a/packages/datacommons-mcp/datacommons_mcp/clients.py
+++ b/packages/datacommons-mcp/datacommons_mcp/clients.py
@@ -33,6 +33,7 @@ from datacommons_mcp.data_models.observations import (
     ObservationRequest,
 )
 from datacommons_mcp.data_models.search import (
+    NodeInfo,
     SearchIndicator,
     SearchResponse,
     SearchResult,
@@ -153,6 +154,26 @@ class DCClient:
     async def fetch_entity_names(self, dcids: list[str]) -> dict:
         response = self.dc.node.fetch_entity_names(entity_dcids=dcids)
         return {dcid: name.value for dcid, name in response.items() if name}
+
+    async def fetch_entity_infos(self, dcids: list[str]) -> dict[str, NodeInfo]:
+        """Fetch entity information including name and type for a list of DCIDs."""
+
+        # Fetch both name and typeOf properties in a single call
+        response = self.dc.node.fetch_property_values(
+            node_dcids=dcids, properties=["name", "typeOf"]
+        )
+
+        result = {}
+        for dcid in dcids:
+            # Extract name from nodes (name properties have .value attribute)
+            name_nodes = response.extract_connected_nodes(dcid, "name")
+            # Extract type from DCIDs (typeOf properties have .dcid attribute)
+            type_dcids = response.extract_connected_dcids(dcid, "typeOf")
+
+            if name_nodes and type_dcids:
+                result[dcid] = NodeInfo(name=name_nodes[0].value, typeOf=type_dcids)
+
+        return result
 
     async def fetch_entity_types(self, dcids: list[str]) -> dict:
         response = self.dc.node.fetch_property_values(

--- a/packages/datacommons-mcp/datacommons_mcp/clients.py
+++ b/packages/datacommons-mcp/datacommons_mcp/clients.py
@@ -171,7 +171,7 @@ class DCClient:
             type_dcids = response.extract_connected_dcids(dcid, "typeOf")
 
             if name_nodes and type_dcids:
-                result[dcid] = NodeInfo(name=name_nodes[0].value, type_of=type_dcids)
+                result[dcid] = NodeInfo(name=name_nodes[0].value, typeOf=type_dcids)
 
         return result
 

--- a/packages/datacommons-mcp/datacommons_mcp/data_models/observations.py
+++ b/packages/datacommons-mcp/datacommons_mcp/data_models/observations.py
@@ -266,8 +266,6 @@ class ToolResponseBaseModel(BaseModel):
 class Node(ToolResponseBaseModel):
     """Represents a Data Commons node, with an optional name, type, and dcid."""
 
-    model_config = {"populate_by_name": True}
-
     dcid: str | None = None
     name: str | None = None
     type_of: list[str] | None = Field(default=None, alias="typeOf")

--- a/packages/datacommons-mcp/datacommons_mcp/data_models/observations.py
+++ b/packages/datacommons-mcp/datacommons_mcp/data_models/observations.py
@@ -266,6 +266,8 @@ class ToolResponseBaseModel(BaseModel):
 class Node(ToolResponseBaseModel):
     """Represents a Data Commons node, with an optional name, type, and dcid."""
 
+    model_config = {"populate_by_name": True}
+
     dcid: str | None = None
     name: str | None = None
     type_of: list[str] | None = Field(default=None, alias="typeOf")

--- a/packages/datacommons-mcp/datacommons_mcp/data_models/search.py
+++ b/packages/datacommons-mcp/datacommons_mcp/data_models/search.py
@@ -14,6 +14,8 @@ from pydantic import BaseModel, Field
 class NodeInfo(BaseModel):
     """Represents node information with name and types."""
 
+    model_config = {"populate_by_name": True}
+
     name: str = Field(description="Human-readable name of the node")
     type_of: list[str] = Field(
         description="All types of the node (e.g., ['State', 'AdministrativeArea1'])",

--- a/packages/datacommons-mcp/datacommons_mcp/data_models/search.py
+++ b/packages/datacommons-mcp/datacommons_mcp/data_models/search.py
@@ -94,8 +94,11 @@ class SearchResponse(BaseModel):
     variables: list[SearchVariable] = Field(
         description="List of variable objects with dcid and places_with_data"
     )
-    nodes: dict[str, NodeInfo] = Field(
-        default_factory=dict, description="DCID to NodeInfo mappings (name and types)"
+    dcid_name_mappings: dict[str, str] = Field(
+        default_factory=dict, description="DCID to human-readable name mappings"
+    )
+    dcid_place_type_mappings: dict[str, list[str]] = Field(
+        default_factory=dict, description="Place DCID to type mappings"
     )
 
     status: str = Field(default="SUCCESS", description="Status of the search operation")

--- a/packages/datacommons-mcp/datacommons_mcp/data_models/search.py
+++ b/packages/datacommons-mcp/datacommons_mcp/data_models/search.py
@@ -94,8 +94,8 @@ class SearchResponse(BaseModel):
     variables: list[SearchVariable] = Field(
         description="List of variable objects with dcid and places_with_data"
     )
-    dcid_name_mappings: dict[str, str] = Field(
-        default_factory=dict, description="DCID to name mappings"
+    nodes: dict[str, NodeInfo] = Field(
+        default_factory=dict, description="DCID to NodeInfo mappings (name and types)"
     )
 
     status: str = Field(default="SUCCESS", description="Status of the search operation")

--- a/packages/datacommons-mcp/datacommons_mcp/data_models/search.py
+++ b/packages/datacommons-mcp/datacommons_mcp/data_models/search.py
@@ -11,6 +11,16 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 
+class NodeInfo(BaseModel):
+    """Represents node information with name and types."""
+
+    name: str = Field(description="Human-readable name of the node")
+    type_of: list[str] = Field(
+        description="All types of the node (e.g., ['State', 'AdministrativeArea1'])",
+        alias="typeOf",
+    )
+
+
 class SearchMode(str, Enum):
     """Enumeration of search modes for the search_indicators tool."""
 

--- a/packages/datacommons-mcp/datacommons_mcp/server.py
+++ b/packages/datacommons-mcp/datacommons_mcp/server.py
@@ -106,7 +106,7 @@ async def get_observations(
         * To get data for all its children (e.g., all counties in California), you **must also** provide the `child_place_type` (e.g., "County").
           **CRITICAL:** Before calling `get_observations` with `child_place_type`, you **MUST** first call `search_indicators` with child sampling to determine the correct child place type.
           **Child Type Determination Logic:**
-          1. Use the `nodes` field from the `search_indicators` response to examine the types of sampled child places
+          1. Use the `dcid_place_type_mappings` field from the `search_indicators` response to examine the types of sampled child places
           2. Use the type that is common to ALL sampled child places
           3. If more than one type is common to all child places, use the most specific type
           4. If there is no common type across all sampled child places, use the majority type (50%+ threshold) if there's a clear majority
@@ -543,38 +543,30 @@ async def search_indicators(
           "places_with_data": ["geoId/06", "country/CAN", "..."]
         }
       ],
-      "nodes": {
-        "dc/t/TopicDcid": {
-          "name": "Readable Topic Name",
-          "typeOf": ["Topic"]
-        },
-        "dc/v/VariableDcid": {
-          "name": "Readable Variable Name",
-          "typeOf": ["StatisticalVariable"]
-        },
-        "geoId/06": {
-          "name": "California",
-          "typeOf": ["State"]
-        },
-        "country/CAN": {
-          "name": "Canada",
-          "typeOf": ["Country"]
-        }
+      "dcid_name_mappings": {
+        "dc/t/TopicDcid": "Readable Topic Name",
+        "dc/v/VariableDcid": "Readable Variable Name",
+        "geoId/06": "California",
+        "country/CAN": "Canada"
+      },
+      "dcid_place_type_mappings": {
+        "geoId/06": ["State"],
+        "country/CAN": ["Country"]
       },
       "status": "SUCCESS"
     }
 
     ### How to Process the Response
 
-      - `topics`: (Only if `include_topics=True`) Collections of variables and sub-topics. Use `nodes` to get readable names for presentation.
+      - `topics`: (Only if `include_topics=True`) Collections of variables and sub-topics. Use `dcid_name_mappings` to get readable names for presentation.
 
-      - `variables`: Individual data indicators. Use `nodes` to get readable names.
+      - `variables`: Individual data indicators. Use `dcid_name_mappings` to get readable names.
 
       - `places_with_data`: (Only if `places` was in the request) A list of *DCIDs* for the requested places that have data for that specific indicator.
 
-      - `nodes`: A dictionary mapping all DCIDs (topics, variables, and places) in the response to their `NodeInfo` objects containing:
-        - `name`: Human-readable name of the entity
-        - `typeOf`: List of entity types (e.g., `["State"]`, `["Country"]`, `["StatisticalVariable"]`, `["Topic"]`)
+      - `dcid_name_mappings`: A dictionary mapping all DCIDs (topics, variables, and places) in the response to their human-readable names.
+
+      - `dcid_place_type_mappings`: A dictionary mapping place DCIDs to their types (e.g., `["State"]`, `["Country"]`). Use this for child place type determination in `get_observations`.
 
     **Final Reminder:** Always treat results as *candidates*. You must filter and rank them based on the user's full context.
     """

--- a/packages/datacommons-mcp/datacommons_mcp/server.py
+++ b/packages/datacommons-mcp/datacommons_mcp/server.py
@@ -15,7 +15,6 @@
 Server module for the DC MCP server.
 """
 
-import asyncio
 import logging
 import types
 from typing import Union, get_args, get_origin
@@ -158,68 +157,6 @@ async def get_observations(
         date_range_start=date_range_start,
         date_range_end=date_range_end,
     )
-
-
-async def validate_child_place_types(
-    parent_place_name: str, child_place_types: list[str]
-) -> dict[str, bool]:
-    """
-    Checks which of the child place types are valid for the parent place.
-
-    Use this tool to validate the child place types before calling get_observations for those places.
-
-    Example:
-    - For counties in Kenya, you can check for both "County" and "AdministrativeArea1" to determine which is valid.
-      i.e. "validate_child_place_types("Kenya", ["County", "AdministrativeArea1"])"
-
-    The full list of valid child place types are the following:
-    - AdministrativeArea1
-    - AdministrativeArea2
-    - AdministrativeArea3
-    - AdministrativeArea4
-    - AdministrativeArea5
-    - Continent
-    - Country
-    - State
-    - County
-    - City
-    - CensusZipCodeTabulationArea
-    - Town
-    - Village
-
-    Valid child place types can vary by parent place. Here are hints for valid child place types for some of the places:
-    - If parent_place_name is a continent (e.g., "Europe") or the world: "Country"
-    - If parent_place_name is the US or a place within it: "State", "County", "City", "CensusZipCodeTabulationArea", "Town", "Village"
-    - For all other countries: The tool uses a standardized hierarchy: "AdministrativeArea1" (primary division), "AdministrativeArea2" (secondary division), "AdministrativeArea3", "AdministrativeArea4", "AdministrativeArea5".
-      Map commonly used administrative level names to the appropriate administrative area type based on this hierarchy before calling this tool.
-      Use these examples as a guide for mapping:
-      - For India: States typically map to 'AdministrativeArea1', districts typically map to 'AdministrativeArea2'.
-      - For Spain: Autonomous communities typically map to 'AdministrativeArea1', provinces typically map to 'AdministrativeArea2'.
-
-
-    Args:
-        parent_place_name: The name of the parent geographic area (e.g., 'Kenya').
-        child_place_types: The canonical child place types to check for (e.g., 'AdministrativeArea1').
-
-    Returns:
-        A dictionary mapping child place types to a boolean indicating whether they are valid for the parent place.
-    """
-    places = await dc_client.search_places([parent_place_name])
-    place_dcid = places.get(parent_place_name, "")
-    if not place_dcid:
-        return dict.fromkeys(child_place_types, False)
-
-    tasks = [
-        dc_client.child_place_type_exists(
-            place_dcid,
-            child_place_type,
-        )
-        for child_place_type in child_place_types
-    ]
-
-    results = await asyncio.gather(*tasks)
-
-    return dict(zip(child_place_types, results, strict=False))
 
 
 # TODO(clincoln8): Add to optional visualization toolset

--- a/packages/datacommons-mcp/datacommons_mcp/server.py
+++ b/packages/datacommons-mcp/datacommons_mcp/server.py
@@ -110,7 +110,7 @@ async def get_observations(
           2. Use the type that is common to ALL sampled child places
           3. If more than one type is common to all child places, use the most specific type
           4. If there is no common type across all sampled child places, use the majority type (50%+ threshold) if there's a clear majority
-          5. If there is no common type and no clear majority, child `get_observations` calls cannot be made - fall back to individual non-child `get_observations` calls for each place
+          5. If there is no common type and no clear majority, this tool cannot be called with child-place mode - fall back to single-place mode `get_observations` calls for each place
           **Note:** If you used child sampling in `search_indicators` to validate variable existence, you should still get data for ALL children of that type, not just the sampled subset.
 
     * **Data Volume Constraint**: When using **Child Places Mode** (when `child_place_type` is set), you **must** be conservative with your date range to avoid requesting too much data.
@@ -363,33 +363,24 @@ async def search_indicators(
 
       - If provided, the tool will only return indicators that have data for at least one of the specified places.
 
-      - **CRITICAL RULES:**
+      **Place Name Qualification (CRITICAL):**
 
-        - **ALWAYS qualify place names** with geographic context to avoid ambiguity (e.g., `"California, USA"`, `"Paris, France"`, `"Springfield, IL"`).
+      - **ALWAYS qualify place names** with geographic context to avoid ambiguity (e.g., `"California, USA"`, `"Paris, France"`, `"Springfield, IL"`).
 
-        - **ALWAYS specify administrative level** when ambiguous For instance:
-    5     - For the city: `"Madrid, Spain"`
-    6     - For the autonomous community: `"Community of Madrid, Spain"`
-    7     - Similarly, differentiate between `"New York City, USA"` and `"New York State, USA"`.
+      - **ALWAYS specify administrative level** when ambiguous:
+        - For the city: `"Madrid, Spain"`
+        - For the autonomous community: `"Community of Madrid, Spain"`
+        - Similarly, differentiate between `"New York City, USA"` and `"New York State, USA"`.
 
-        - **ALWAYS** use qualified, readable names (e.g., `"California, USA"`, `"Canada"`, `"World"`).
-
-        - **NEVER** use DCIDs (e.g., `"geoId/06"`, `"country/CAN"`).
-
-        - If you get place info from another tool, extract and use *only* the readable name, but always qualify it with geographic context.
-
-        - **CRITICAL:** Always qualify place names to avoid ambiguity (e.g., `"Scotland, UK"` not `"Scotland"`, `"California, USA"` not `"California"`).
-
-      **Place Name Qualification Guidelines:**
-
-      - **Geographic Disambiguation:** Add country/region context (e.g., `"Scotland, UK"` vs `"Scotland County, USA"`)
-      - **Administrative Level Disambiguation:** Specify city vs state vs country level (e.g., `"New York City, USA"` vs `"New York State, USA"`)
       - **Common Ambiguous Cases:**
         - **New York:** `"New York City, USA"` vs `"New York State, USA"`
         - **Madrid:** `"Madrid, Spain"` (city) vs `"Community of Madrid, Spain"`
         - **London:** `"London, UK"` (city) vs `"London, Ontario, Canada"`
         - **Washington:** `"Washington, DC, USA"` vs `"Washington State, USA"`
         - **Springfield:** `"Springfield, IL, USA"` vs `"Springfield, MO, USA"` (add state)
+
+      - **NEVER** use DCIDs (e.g., `"geoId/06"`, `"country/CAN"`).
+      - If you get place info from another tool, extract and use *only* the readable name, but always qualify it with geographic context.
 
       - When searching for indicators related to child places within a larger geographic entity (e.g., states within a country, or countries within a continent/the world), you MUST include the parent entity and a diverse sample of 5-6 of its child places in the `places` list.
        This ensures the discovery of indicators that have data at the child place level. Refer to 'Recipe 4: Sampling Child Places' for detailed examples.

--- a/packages/datacommons-mcp/datacommons_mcp/services.py
+++ b/packages/datacommons-mcp/datacommons_mcp/services.py
@@ -35,6 +35,7 @@ from datacommons_mcp.data_models.observations import (
     TimeSeriesPoint,
 )
 from datacommons_mcp.data_models.search import (
+    NodeInfo,
     SearchResponse,
     SearchResult,
     SearchTask,
@@ -528,7 +529,7 @@ async def search_indicators(
     # Create unified response
     return SearchResponse(
         status="SUCCESS",
-        dcid_name_mappings=lookups,
+        nodes=lookups,
         topics=list(search_result.topics.values()),
         variables=list(search_result.variables.values()),
     )
@@ -687,13 +688,15 @@ async def _search_vector(
     return await _merge_search_results(results)
 
 
-async def _fetch_and_update_lookups(client: DCClient, dcids: list[str]) -> dict:
-    """Fetch names for all DCIDs and return as lookups dictionary."""
+async def _fetch_and_update_lookups(
+    client: DCClient, dcids: list[str]
+) -> dict[str, NodeInfo]:
+    """Fetch entity information for all DCIDs and return as nodes dictionary."""
     if not dcids:
         return {}
 
     try:
-        return await client.fetch_entity_names(dcids)
+        return await client.fetch_entity_infos(dcids)
     except Exception:  # noqa: BLE001
         # If fetching fails, return empty dict (not an error)
         return {}

--- a/packages/datacommons-mcp/datacommons_mcp/services.py
+++ b/packages/datacommons-mcp/datacommons_mcp/services.py
@@ -526,10 +526,19 @@ async def search_indicators(
     # Fetch lookups
     lookups = await _fetch_and_update_lookups(client, list(all_dcids))
 
+    place_dcids = set(place_dcids_map.values())
+    dcid_name_mappings = {}
+    dcid_place_type_mappings = {}
+    for dcid, info in lookups.items():
+        dcid_name_mappings[dcid] = info.name
+        if dcid in place_dcids:
+            dcid_place_type_mappings[dcid] = info.type_of
+
     # Create unified response
     return SearchResponse(
         status="SUCCESS",
-        nodes=lookups,
+        dcid_name_mappings=dcid_name_mappings,
+        dcid_place_type_mappings=dcid_place_type_mappings,
         topics=list(search_result.topics.values()),
         variables=list(search_result.variables.values()),
     )

--- a/packages/datacommons-mcp/tests/test_dc_client.py
+++ b/packages/datacommons-mcp/tests/test_dc_client.py
@@ -34,6 +34,7 @@ from datacommons_mcp.data_models.observations import (
     ObservationRequest,
 )
 from datacommons_mcp.data_models.search import (
+    NodeInfo,
     SearchResult,
     SearchTask,
     SearchTopic,
@@ -1806,3 +1807,52 @@ class TestCreateDCClient:
                 mock_custom_store.merge.assert_called_once_with(mock_base_store)
             else:
                 mock_custom_store.merge.assert_not_called()
+
+
+class TestFetchEntityInfos:
+    """Test the fetch_entity_infos method."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_entity_infos(self):
+        """Test successful fetch of entity information."""
+
+        # Mock data - simple dict from dcid to name and typeOf
+        mock_data = {
+            "geoId/06": {"name": "California", "typeOf": ["State"]},
+            "country/USA": {"name": "United States", "typeOf": ["Country"]},
+        }
+
+        # Mock the underlying DC client
+        mock_dc = Mock()
+        mock_response = Mock()
+        mock_dc.node.fetch_property_values.return_value = mock_response
+
+        # Mock the extract_connected_nodes method for names
+        def mock_extract_connected_nodes(dcid, property_name):
+            if property_name == "name" and dcid in mock_data:
+                return [Mock(value=mock_data[dcid]["name"])]
+            return []
+
+        # Mock the extract_connected_dcids method for types
+        def mock_extract_connected_dcids(dcid, property_name):
+            if property_name == "typeOf" and dcid in mock_data:
+                return mock_data[dcid]["typeOf"]
+            return []
+
+        mock_response.extract_connected_nodes.side_effect = mock_extract_connected_nodes
+        mock_response.extract_connected_dcids.side_effect = mock_extract_connected_dcids
+
+        client = DCClient(dc=mock_dc)
+        result = await client.fetch_entity_infos(["geoId/06", "country/USA"])
+
+        # Verify the entire result
+        expected_result = {
+            "geoId/06": NodeInfo(name="California", typeOf=["State"]),
+            "country/USA": NodeInfo(name="United States", typeOf=["Country"]),
+        }
+        assert result == expected_result
+
+        # Verify the underlying methods were called
+        mock_dc.node.fetch_property_values.assert_called_once_with(
+            node_dcids=["geoId/06", "country/USA"], properties=["name", "typeOf"]
+        )

--- a/packages/datacommons-mcp/tests/test_services.py
+++ b/packages/datacommons-mcp/tests/test_services.py
@@ -21,6 +21,7 @@ from datacommons_mcp.data_models.observations import (
     ObservationDateType,
     ObservationToolResponse,
 )
+from datacommons_mcp.data_models.search import NodeInfo
 from datacommons_mcp.exceptions import (
     DataLookupError,
     InvalidDateFormatError,
@@ -43,7 +44,7 @@ class TestGetObservations:
         mock = Mock(spec_set=DCClient)
         mock.search_places = AsyncMock()
         mock.fetch_obs = AsyncMock()
-        mock.fetch_entity_names = AsyncMock()
+        mock.fetch_entity_infos = AsyncMock()
         mock.fetch_entity_types = AsyncMock()
         return mock
 
@@ -820,7 +821,7 @@ class TestSearchIndicators:
         mock_client.fetch_indicators = AsyncMock(
             return_value={"topics": [], "variables": [], "lookups": {}}
         )
-        mock_client.fetch_entity_names = AsyncMock(return_value={})
+        mock_client.fetch_entity_infos = AsyncMock(return_value={})
         result = await search_indicators(
             client=mock_client,
             query="health",
@@ -828,7 +829,7 @@ class TestSearchIndicators:
 
         assert result.topics is not None
         assert result.variables is not None
-        assert result.dcid_name_mappings is not None
+        assert result.nodes is not None
         assert result.status == "SUCCESS"
         mock_client.fetch_indicators.assert_called_once_with(
             query="health", place_dcids=[], include_topics=True, max_results=10
@@ -854,11 +855,15 @@ class TestSearchIndicators:
                 },
             }
         )
-        mock_client.fetch_entity_names = AsyncMock(
+        mock_client.fetch_entity_infos = AsyncMock(
             return_value={
-                "topic/trade": "Trade",
-                "TradeExports_FRA": "Exports to France",
-                "TradeImports_FRA": "Imports from France",
+                "topic/trade": NodeInfo(name="Trade", typeOf=["Topic"]),
+                "TradeExports_FRA": NodeInfo(
+                    name="Exports to France", typeOf=["StatisticalVariable"]
+                ),
+                "TradeImports_FRA": NodeInfo(
+                    name="Imports from France", typeOf=["StatisticalVariable"]
+                ),
             }
         )
 
@@ -874,6 +879,17 @@ class TestSearchIndicators:
         assert actual_topic_dcids == expected_topic_dcids
         assert actual_variable_dcids == expected_variable_dcids
 
+        # Verify that fetch_entity_infos is called with the correct DCIDs
+        expected_dcids = {
+            "topic/trade",
+            "TradeExports_FRA",
+            "TradeImports_FRA",
+            "country/FRA",
+        }
+        mock_client.fetch_entity_infos.assert_called_once()
+        actual_dcids = set(mock_client.fetch_entity_infos.call_args[0][0])
+        assert actual_dcids == expected_dcids
+
     @pytest.mark.asyncio
     async def test_search_indicators_browse_mode_with_custom_per_search_limit(self):
         """Test search in browse mode with custom per_search_limit parameter."""
@@ -886,8 +902,13 @@ class TestSearchIndicators:
                 "lookups": {"topic/health": "Health", "Count_Person": "Population"},
             }
         )
-        mock_client.fetch_entity_names = AsyncMock(
-            return_value={"topic/health": "Health", "Count_Person": "Population"}
+        mock_client.fetch_entity_infos = AsyncMock(
+            return_value={
+                "topic/health": NodeInfo(name="Health", typeOf=["Topic"]),
+                "Count_Person": NodeInfo(
+                    name="Population", typeOf=["StatisticalVariable"]
+                ),
+            }
         )
 
         await search_indicators(client=mock_client, query="health", per_search_limit=5)
@@ -938,11 +959,15 @@ class TestSearchIndicators:
                 "variables": [{"dcid": "Count_Person"}, {"dcid": "Count_Household"}],
             }
         )
-        mock_client.fetch_entity_names = AsyncMock(
+        mock_client.fetch_entity_infos = AsyncMock(
             return_value={
-                "Count_Person": "Population",
-                "Count_Household": "Households",
-                "country/USA": "USA",
+                "Count_Person": NodeInfo(
+                    name="Population", typeOf=["StatisticalVariable"]
+                ),
+                "Count_Household": NodeInfo(
+                    name="Households", typeOf=["StatisticalVariable"]
+                ),
+                "country/USA": NodeInfo(name="USA", typeOf=["Country"]),
             }
         )
 
@@ -979,12 +1004,16 @@ class TestSearchIndicators:
                 },  # query + Germany (filtered by France)
             ]
         )
-        mock_client.fetch_entity_names = AsyncMock(
+        mock_client.fetch_entity_infos = AsyncMock(
             return_value={
-                "TradeExports_FRA": "Exports to France",
-                "TradeExports_DEU": "Exports to Germany",
-                "country/FRA": "France",
-                "country/DEU": "Germany",
+                "TradeExports_FRA": NodeInfo(
+                    name="Exports to France", typeOf=["StatisticalVariable"]
+                ),
+                "TradeExports_DEU": NodeInfo(
+                    name="Exports to Germany", typeOf=["StatisticalVariable"]
+                ),
+                "country/FRA": NodeInfo(name="France", typeOf=["Country"]),
+                "country/DEU": NodeInfo(name="Germany", typeOf=["Country"]),
             }
         )
 
@@ -1032,7 +1061,7 @@ class TestSearchIndicators:
         # Test valid per_search_limit values with place (so lookup mode is actually used)
         mock_client.search_places = AsyncMock(return_value={"USA": "country/USA"})
         mock_client.fetch_indicators = AsyncMock(return_value={"variables": []})
-        mock_client.fetch_entity_names = AsyncMock(return_value={"country/USA": "USA"})
+        mock_client.fetch_entity_infos = AsyncMock(return_value={})
 
         # Should not raise for valid values
         await search_indicators(
@@ -1061,8 +1090,12 @@ class TestSearchIndicators:
                 "lookups": {"Count_Person": "Population"},
             }
         )
-        mock_client.fetch_entity_names = AsyncMock(
-            return_value={"Count_Person": "Population"}
+        mock_client.fetch_entity_infos = AsyncMock(
+            return_value={
+                "Count_Person": NodeInfo(
+                    name="Population", typeOf=["StatisticalVariable"]
+                )
+            }
         )
 
         # Call with lookup mode but no places - should automatically fall back to browse mode
@@ -1075,7 +1108,7 @@ class TestSearchIndicators:
         # Should return lookup mode results (variables only)
         assert result.topics == []
         assert result.variables is not None
-        assert result.dcid_name_mappings is not None
+        assert result.nodes is not None
         assert result.status == "SUCCESS"
         mock_client.fetch_indicators.assert_called_once_with(
             query="health", place_dcids=[], include_topics=False, max_results=10
@@ -1096,7 +1129,7 @@ class TestSearchIndicators:
         mock_client.fetch_indicators = AsyncMock(
             return_value={"topics": [], "variables": [], "lookups": {}}
         )
-        mock_client.fetch_entity_names = AsyncMock(return_value={})
+        mock_client.fetch_entity_infos = AsyncMock(return_value={})
 
         # Test 1: Single place including topics
         result = await search_indicators(
@@ -1120,7 +1153,7 @@ class TestSearchIndicators:
         mock_client.fetch_indicators = AsyncMock(
             return_value={"topics": [], "variables": [], "lookups": {}}
         )
-        mock_client.fetch_entity_names = AsyncMock(return_value={})
+        mock_client.fetch_entity_infos = AsyncMock(return_value={})
 
         # Test 2: Single place variables-only
         result = await search_indicators(
@@ -1151,7 +1184,7 @@ class TestSearchIndicators:
         mock_client.fetch_indicators = AsyncMock(
             return_value={"topics": [], "variables": [], "lookups": {}}
         )
-        mock_client.fetch_entity_names = AsyncMock(return_value={})
+        mock_client.fetch_entity_infos = AsyncMock(return_value={})
 
         # Test 3: Multiple places including topics
         result = await search_indicators(
@@ -1179,7 +1212,7 @@ class TestSearchIndicators:
         mock_client.fetch_indicators = AsyncMock(
             return_value={"topics": [], "variables": [], "lookups": {}}
         )
-        mock_client.fetch_entity_names = AsyncMock(return_value={})
+        mock_client.fetch_entity_infos = AsyncMock(return_value={})
 
         # Test 1: Maybe bilateral including topics
         result = await search_indicators(
@@ -1225,7 +1258,7 @@ class TestSearchIndicators:
         mock_client.fetch_indicators = AsyncMock(
             return_value={"topics": [], "variables": [], "lookups": {}}
         )
-        mock_client.fetch_entity_names = AsyncMock(return_value={})
+        mock_client.fetch_entity_infos = AsyncMock(return_value={})
 
         # Test 2: Maybe bilateral variables-only
         result = await search_indicators(
@@ -1272,7 +1305,7 @@ class TestSearchIndicators:
             return_value={"USA": "country/USA", "France": "country/FRA"}
         )
         mock_client.fetch_indicators = AsyncMock(return_value={"variables": []})
-        mock_client.fetch_entity_names = AsyncMock(return_value={})
+        mock_client.fetch_entity_infos = AsyncMock(return_value={})
 
         # Test maybe_bilateral=True with places (should work)
         result = await search_indicators(
@@ -1291,7 +1324,7 @@ class TestSearchIndicators:
             return_value={"USA": "country/USA", "France": "country/FRA"}
         )
         mock_client.fetch_indicators = AsyncMock(return_value={"variables": []})
-        mock_client.fetch_entity_names = AsyncMock(return_value={})
+        mock_client.fetch_entity_infos = AsyncMock(return_value={})
 
         result = await search_indicators(
             client=mock_client,

--- a/packages/datacommons-mcp/tests/test_services.py
+++ b/packages/datacommons-mcp/tests/test_services.py
@@ -829,7 +829,7 @@ class TestSearchIndicators:
 
         assert result.topics is not None
         assert result.variables is not None
-        assert result.nodes is not None
+        assert result.dcid_name_mappings is not None
         assert result.status == "SUCCESS"
         mock_client.fetch_indicators.assert_called_once_with(
             query="health", place_dcids=[], include_topics=True, max_results=10
@@ -1108,7 +1108,7 @@ class TestSearchIndicators:
         # Should return lookup mode results (variables only)
         assert result.topics == []
         assert result.variables is not None
-        assert result.nodes is not None
+        assert result.dcid_name_mappings is not None
         assert result.status == "SUCCESS"
         mock_client.fetch_indicators.assert_called_once_with(
             query="health", place_dcids=[], include_topics=False, max_results=10


### PR DESCRIPTION
* Replaced `validate_child_place_types` tool with a ~`nodes`~ `dcid_place_type_mappings` field in `search_indicators` responses
* Added place name qualification guidance
* Update all examples to use qualified place names
* Updated `get_observations` instructions to use ~`nodes`~ `dcid_place_type_mappings`  field for child place type determination
* Tested with various types of queries - from the bug bash and new ones - in gemini cli
  - We should now prioritize our evals coverage so we can include these in evals
  - If you get a chance, please try a few yourself with this change

#### ~Fast follow~
* ~The types in the new `nodes` field are redundant for SVs and topics. The former can be too many for large topics and lead to context window overflows in some cases~
* ~I'll do a fast-follow where we go back to the dcid-name mappings field and add a separate dcid-type mappings field for just places~
* Made the above change already in this PR - basically instead of returning a `nodes` field with both names and types for all dcids, names now continue to be returned in `dcid_name_mappings`. And we now have a new `dcid_place_type_mappings` field for types just for places
  + This has reduced the response sizes and I don't see the issues I saw with context window overflows earlier
* In general, let's always be mindful of response sizes, even if it means sacrificing some structural elegance