### PR TITLE
Add multi-entity observation support and researcher skill

### DIFF
--- a/packages/datacommons-mcp/.env.sample
+++ b/packages/datacommons-mcp/.env.sample
@@ -55,6 +55,7 @@ DC_TYPE=base
 # Expected structure inside this directory:
 # - server.md
 # - tools/{tool_name}.md
+# (Note: If DC_USE_AGENT_API=true, place these inside an "agent_api" subdirectory: agent_api/server.md, agent_api/tools/{tool_name}.md)
 # DC_INSTRUCTIONS_DIR=/path/to/custom/instructions
 
 # Enable using Agent-optimized APIs instead of local processing (optional)

--- a/packages/datacommons-mcp/datacommons_mcp/agent_api_service.py
+++ b/packages/datacommons-mcp/datacommons_mcp/agent_api_service.py
@@ -19,6 +19,7 @@ from typing import Any
 
 from datacommons_mcp.agent_api_client import AgentAPIClient
 from datacommons_mcp.app import app
+from datacommons_mcp.data_models.observations import ObservationDateType
 
 
 def _get_agent_api_client() -> AgentAPIClient:
@@ -69,7 +70,7 @@ async def get_multi_entity_observations(
     parent_entity_dcid: str | None = None,
     child_entity_type: str | None = None,
     source_override: str | None = None,
-    date: str | None = None,
+    date: str | None = ObservationDateType.LATEST.value,
     date_range_start: str | None = None,
     date_range_end: str | None = None,
 ) -> dict[str, Any]:
@@ -77,8 +78,18 @@ async def get_multi_entity_observations(
     client = _get_agent_api_client()
     entities_payload: dict[str, Any] = dict(entities)
 
-    if parent_entity_property and parent_entity_dcid and child_entity_type:
-        entities_payload[parent_entity_property] = {
+    child_expansion_params = [
+        parent_entity_property,
+        parent_entity_dcid,
+        child_entity_type,
+    ]
+    if any(child_expansion_params):
+        if not all(child_expansion_params):
+            raise ValueError(
+                "To use child entity expansion, all of 'parent_entity_property', "
+                "'parent_entity_dcid', and 'child_entity_type' must be provided."
+            )
+        entities_payload[parent_entity_property] = {  # type: ignore[index]
             "parent_dcid": parent_entity_dcid,
             "child_type": child_entity_type,
         }

--- a/packages/datacommons-mcp/datacommons_mcp/agent_api_service.py
+++ b/packages/datacommons-mcp/datacommons_mcp/agent_api_service.py
@@ -89,6 +89,11 @@ async def get_multi_entity_observations(
                 "To use child entity expansion, all of 'parent_entity_property', "
                 "'parent_entity_dcid', and 'child_entity_type' must be provided."
             )
+        if parent_entity_property in entities_payload:
+            raise ValueError(
+                f"Property '{parent_entity_property}' cannot be specified in both 'entities' "
+                "and child expansion parameters."
+            )
         entities_payload[parent_entity_property] = {  # type: ignore[index]
             "parent_dcid": parent_entity_dcid,
             "child_type": child_entity_type,

--- a/packages/datacommons-mcp/datacommons_mcp/agent_api_service.py
+++ b/packages/datacommons-mcp/datacommons_mcp/agent_api_service.py
@@ -39,12 +39,53 @@ async def get_observations(
     date_range_start: str | None = None,
     date_range_end: str | None = None,
 ) -> dict[str, Any]:
-    """Fetches observations via the Agent API agent/get_observations endpoint."""
+    """Fetches single-place or child-place observations via agent/get_observations."""
     client = _get_agent_api_client()
+    if child_place_type:
+        entities: dict[str, Any] = {
+            "observationAbout": {
+                "parent_dcid": place_dcid,
+                "child_type": child_place_type,
+            }
+        }
+    else:
+        entities = {"observationAbout": [place_dcid]}
+
     payload = {
         "variable_dcid": variable_dcid,
-        "place_dcid": place_dcid,
-        "child_place_type": child_place_type,
+        "entities": entities,
+        "source_override": source_override,
+        "date": date,
+        "date_range_start": date_range_start,
+        "date_range_end": date_range_end,
+    }
+    return await client.post("agent/get_observations", payload)
+
+
+async def get_multi_entity_observations(
+    variable_dcid: str,
+    entities: dict[str, list[str]],
+    parent_entity_property: str | None = None,
+    parent_entity_dcid: str | None = None,
+    child_entity_type: str | None = None,
+    source_override: str | None = None,
+    date: str | None = None,
+    date_range_start: str | None = None,
+    date_range_end: str | None = None,
+) -> dict[str, Any]:
+    """Fetches multi-entity observations via the Agent API agent/get_observations endpoint."""
+    client = _get_agent_api_client()
+    entities_payload: dict[str, Any] = dict(entities)
+
+    if parent_entity_property and parent_entity_dcid and child_entity_type:
+        entities_payload[parent_entity_property] = {
+            "parent_dcid": parent_entity_dcid,
+            "child_type": child_entity_type,
+        }
+
+    payload = {
+        "variable_dcid": variable_dcid,
+        "entities": entities_payload,
         "source_override": source_override,
         "date": date,
         "date_range_start": date_range_start,

--- a/packages/datacommons-mcp/datacommons_mcp/agent_api_tools.py
+++ b/packages/datacommons-mcp/datacommons_mcp/agent_api_tools.py
@@ -18,6 +18,9 @@ Tool implementations for the Agent API-based Data Commons MCP server.
 from typing import Any
 
 from datacommons_mcp.agent_api_service import (
+    get_multi_entity_observations as agent_api_get_multi_entity_observations,
+)
+from datacommons_mcp.agent_api_service import (
     get_observations as agent_api_get_observations,
 )
 from datacommons_mcp.agent_api_service import (
@@ -34,6 +37,9 @@ SEARCH_CHILD_INDICATORS_INSTRUCTION_FILE = "tools/search_child_indicators.md"
 GET_VARIABLE_METADATA_INSTRUCTION_FILE = "tools/get_variable_metadata.md"
 GET_OBSERVATIONS_INSTRUCTION_FILE = "tools/get_observations.md"
 GET_CHILD_OBSERVATIONS_INSTRUCTION_FILE = "tools/get_child_observations.md"
+GET_MULTI_ENTITY_OBSERVATIONS_INSTRUCTION_FILE = (
+    "tools/get_multi_entity_observations.md"
+)
 
 
 async def search_indicators(
@@ -116,6 +122,31 @@ async def get_child_observations(
         variable_dcid=variable_dcid,
         place_dcid=parent_place_dcid,
         child_place_type=child_place_type,
+        source_override=source_override,
+        date=date,
+        date_range_start=date_range_start,
+        date_range_end=date_range_end,
+    )
+
+
+async def get_multi_entity_observations(
+    variable_dcid: str,
+    entities: dict[str, list[str]],
+    parent_entity_property: str | None = None,
+    parent_entity_dcid: str | None = None,
+    child_entity_type: str | None = None,
+    source_override: str | None = None,
+    date: str = ObservationDateType.LATEST.value,
+    date_range_start: str | None = None,
+    date_range_end: str | None = None,
+) -> dict[str, Any]:
+    """Fetches observations for multi-entity relationship statistical variables."""
+    return await agent_api_get_multi_entity_observations(
+        variable_dcid=variable_dcid,
+        entities=entities,
+        parent_entity_property=parent_entity_property,
+        parent_entity_dcid=parent_entity_dcid,
+        child_entity_type=child_entity_type,
         source_override=source_override,
         date=date,
         date_range_start=date_range_start,

--- a/packages/datacommons-mcp/datacommons_mcp/instructions/agent_api/server.md
+++ b/packages/datacommons-mcp/datacommons_mcp/instructions/agent_api/server.md
@@ -6,3 +6,5 @@ CRITICAL INSTRUCTION: When performing statistical research, searching for indica
 - `skill://data-commons-multi-entity-researcher/SKILL.md` (for bilateral relationships, flows, foreign aid, trade, or multi-entity queries)
 
 Crucially, every data point retrieved must be attributed to its original source provided in the tool output; never present statistics as "known facts" without citing the specific organization or dataset they originated from. Prioritize data integrity and transparency, ensuring that users understand both the metric and the provenance of the information provided.
+
+CRITICAL RULE ON DCIDs: Before calling any observation or metadata tool, you MUST resolve variable and place DCIDs using search tools (`search_indicators` or `search_child_indicators`) even if it means making a similar looking search call again for a place or entity you don't have the DCID for. DO NOT guess or hardcode DCIDs under ANY circumstances. Never assume a DCID based on similar looking DCIDs you have seen previously.

--- a/packages/datacommons-mcp/datacommons_mcp/instructions/agent_api/server.md
+++ b/packages/datacommons-mcp/datacommons_mcp/instructions/agent_api/server.md
@@ -3,5 +3,6 @@ Act as a Data Commons Research Assistant. This server provides direct access to 
 CRITICAL INSTRUCTION: When performing statistical research, searching for indicators, or fetching observations, you MUST first read the appropriate **MCP Resource** before calling any tools. Use your platform's standard MCP resource-reading capability to retrieve:
 - `skill://data-commons-researcher/SKILL.md` (for single-place queries)
 - `skill://data-commons-child-places-researcher/SKILL.md` (for child-places, sub-national breakdowns, or geographic hierarchies)
+- `skill://data-commons-multi-entity-researcher/SKILL.md` (for bilateral relationships, flows, foreign aid, trade, or multi-entity queries)
 
 Crucially, every data point retrieved must be attributed to its original source provided in the tool output; never present statistics as "known facts" without citing the specific organization or dataset they originated from. Prioritize data integrity and transparency, ensuring that users understand both the metric and the provenance of the information provided.

--- a/packages/datacommons-mcp/datacommons_mcp/instructions/agent_api/skills/data-commons-child-places-researcher/SKILL.md
+++ b/packages/datacommons-mcp/datacommons_mcp/instructions/agent_api/skills/data-commons-child-places-researcher/SKILL.md
@@ -31,6 +31,10 @@ When researching statistics across child places within a parent entity, always s
 * Only use DCIDs returned by `search_child_indicators` - never guess or assume variable-place combinations.
 * This ensures data availability and prevents errors from invalid combinations.
 
+### Multi-Entity Discovery Routing Hook
+After calling `search_child_indicators` or `get_variable_metadata`, inspect the `observation_properties` list on candidate variables:
+* If `observation_properties` contains multiple entity properties (e.g. `["donor", "recipient"]` or `["exportingEntity", "importingEntity"]`), this indicator is a **Multi-Entity Statistical Variable**. You MUST switch to reading `skill://data-commons-multi-entity-researcher/SKILL.md` and call `get_multi_entity_observations`.
+
 ---
 
 ## 2. Discovery Heuristics: Concept Splitting & Parameter Tuning

--- a/packages/datacommons-mcp/datacommons_mcp/instructions/agent_api/skills/data-commons-multi-entity-researcher/SKILL.md
+++ b/packages/datacommons-mcp/datacommons_mcp/instructions/agent_api/skills/data-commons-multi-entity-researcher/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: data-commons-multi-entity-researcher
+description: Guidelines, heuristics, and workflows for discovering, assessing, and retrieving observations for multi-entity relationship statistical variables (e.g. foreign aid flows, bilateral trade, international migration) from Data Commons.
+---
+
+## Foundational Knowledge: Multi-Entity Graph Model
+
+Data Commons models complex relationships between multiple entities using **Multi-Entity Statistical Variables**. Unlike standard single-entity variables that measure a property of one location (`observationAbout`), multi-entity variables track directed interactions, flows, or interactions between multiple entity roles (e.g., `donor` and `recipient`, `exportingEntity` and `importingEntity`, `origin` and `destination`).
+
+---
+
+## 1. The Three-Step Multi-Entity Tool Pipeline
+
+When researching multi-entity relationship statistics, separate your work into three distinct phases:
+
+1. **Discovery (`search_indicators`)**: Find candidate variables for your concept (e.g., query `"gross ODA aid"`). Inspect the returned `observation_properties` list on each variable candidate (e.g., `["donor", "recipient"]`).
+2. **Assessment (`get_variable_metadata`)**: Pass candidate variables and entity DCIDs to verify dataset coverage, date ranges, provenances, and confirm the specific `observationProperties`.
+3. **Retrieval (`get_multi_entity_observations`)**: Fetch the observation tables using the mapped entity properties.
+
+---
+
+## 2. Parameter Configuration & Entity Property Mapping
+
+### A. Entity Mapping (`entities` dictionary - Required)
+Map each entity property key (from `observation_properties`, e.g. `"donor"`, `"recipient"`) to its corresponding list of entity DCIDs:
+* *Direct Bilateral Pair*:
+  ```json
+  "entities": {
+    "donor": ["country/ARE"],
+    "recipient": ["country/AFG"]
+  }
+  ```
+
+### B. Child Entity Expansion
+To fetch observations across child places for a target property (e.g. UAE aid to all recipient countries):
+* Set fixed DCIDs in `entities` for known roles (e.g. `"donor": ["country/ARE"]`).
+* Set flat child expansion fields for the target property:
+  - `parent_entity_property`: `"recipient"`
+  - `parent_entity_dcid`: `"Earth"`
+  - `child_entity_type`: `"Country"`
+
+---
+
+## 3. Playbook Recipes & Call Examples
+
+### Recipe 1: Direct Bilateral Pair (e.g., "Foreign aid from UAE to Afghanistan")
+* **Step 1 (Discovery)**: `search_indicators(query="official development assistance")`
+* **Step 2 (Assessment)**: `get_variable_metadata(variable_dcids=["Amount_EconomicActivity_GrossODA"], entity_dcids=["country/ARE", "country/AFG"])`
+* **Step 3 (Retrieval)**: `get_multi_entity_observations(variable_dcid="Amount_EconomicActivity_GrossODA", entities={"donor": ["country/ARE"], "recipient": ["country/AFG"]})`
+
+### Recipe 2: Multi-Entity Child Expansion (e.g., "Foreign aid from UAE to all countries")
+* **Step 1 (Discovery)**: `search_indicators(query="official development assistance")`
+* **Step 2 (Assessment)**: `get_variable_metadata(variable_dcids=["Amount_EconomicActivity_GrossODA"], entity_dcids=["country/ARE"])`
+* **Step 3 (Retrieval)**: `get_multi_entity_observations(variable_dcid="Amount_EconomicActivity_GrossODA", entities={"donor": ["country/ARE"]}, parent_entity_property="recipient", parent_entity_dcid="Earth", child_entity_type="Country")`
+
+---
+
+## 4. Processing Multi-Entity Responses
+
+All observation responses return a uniform dual-table structure:
+1. **`entityMetadata`**: Maps entity DCIDs to human-readable names and types (e.g., `"country/ARE"` -> `"United Arab Emirates"`).
+2. **`data` Table**: Matrix of observations containing columns for each entity property, `date`, and `value`.
+
+Always join `entityMetadata` with the `data` table rows to present human-readable entity names and cite the authoritative data source provenance.

--- a/packages/datacommons-mcp/datacommons_mcp/instructions/agent_api/skills/data-commons-researcher/SKILL.md
+++ b/packages/datacommons-mcp/datacommons_mcp/instructions/agent_api/skills/data-commons-researcher/SKILL.md
@@ -31,6 +31,10 @@ When researching statistics for specific places, always separate your work into 
 * Only use DCIDs returned by `search_indicators` - never guess or assume variable-place combinations.
 * This ensures data availability and prevents errors from invalid combinations.
 
+### Multi-Entity Discovery Routing Hook
+After calling `search_indicators` or `get_variable_metadata`, inspect the `observation_properties` list on candidate variables:
+* If `observation_properties` contains multiple entity properties (e.g. `["donor", "recipient"]` or `["exportingEntity", "importingEntity"]`), this indicator is a **Multi-Entity Statistical Variable**. You MUST switch to reading `skill://data-commons-multi-entity-researcher/SKILL.md` and call `get_multi_entity_observations`.
+
 ---
 
 ## 2. Discovery Heuristics: Concept Splitting & Parameter Tuning

--- a/packages/datacommons-mcp/datacommons_mcp/instructions/agent_api/tools/get_multi_entity_observations.md
+++ b/packages/datacommons-mcp/datacommons_mcp/instructions/agent_api/tools/get_multi_entity_observations.md
@@ -7,7 +7,7 @@ Fetches time-series observations for multi-entity relationship statistical varia
 - `parent_entity_dcid` (optional, string): Parent place DCID for child place expansion (e.g. `"Earth"`).
 - `child_entity_type` (optional, string): Child place type for child place expansion (e.g. `"Country"`).
 - `source_override` (optional, string): Filter by a specific data source provenance DCID.
-- `date` (optional, string): Specific date or `"latest"` (default).
+- `date` (optional, string): Specific date (e.g., `"2024"`), `"all"` (for complete historical time series), or `"latest"` (default).
 - `date_range_start` / `date_range_end` (optional, string): Date range boundaries.
 
 ### Usage Example (Direct Bilateral Pair)

--- a/packages/datacommons-mcp/datacommons_mcp/instructions/agent_api/tools/get_multi_entity_observations.md
+++ b/packages/datacommons-mcp/datacommons_mcp/instructions/agent_api/tools/get_multi_entity_observations.md
@@ -10,6 +10,8 @@ Fetches time-series observations for multi-entity relationship statistical varia
 - `date` (optional, string): Specific date (e.g., `"2024"`), `"all"` (for complete historical time series), or `"latest"` (default).
 - `date_range_start` / `date_range_end` (optional, string): Date range boundaries.
 
+*Important: `parent_entity_property`, `parent_entity_dcid`, and `child_entity_type` are co-dependent. If requesting child expansion, all three must be specified together.*
+
 ### Usage Example (Direct Bilateral Pair)
 ```json
 {

--- a/packages/datacommons-mcp/datacommons_mcp/instructions/agent_api/tools/get_multi_entity_observations.md
+++ b/packages/datacommons-mcp/datacommons_mcp/instructions/agent_api/tools/get_multi_entity_observations.md
@@ -1,0 +1,35 @@
+Fetches time-series observations for multi-entity relationship statistical variables (e.g. foreign aid flows, bilateral trade, international migration).
+
+### Parameters
+- `variable_dcid` (required, string): Statistical variable DCID (e.g., `"Amount_EconomicActivity_GrossODA"`).
+- `entities` (required, dictionary of string lists): Map of entity property names to list of entity DCIDs (e.g. `{"donor": ["country/ARE"], "recipient": ["country/AFG"]}`).
+- `parent_entity_property` (optional, string): Entity property name for child place expansion (e.g. `"recipient"`).
+- `parent_entity_dcid` (optional, string): Parent place DCID for child place expansion (e.g. `"Earth"`).
+- `child_entity_type` (optional, string): Child place type for child place expansion (e.g. `"Country"`).
+- `source_override` (optional, string): Filter by a specific data source provenance DCID.
+- `date` (optional, string): Specific date or `"latest"` (default).
+- `date_range_start` / `date_range_end` (optional, string): Date range boundaries.
+
+### Usage Example (Direct Bilateral Pair)
+```json
+{
+  "variable_dcid": "Amount_EconomicActivity_GrossODA",
+  "entities": {
+    "donor": ["country/ARE"],
+    "recipient": ["country/AFG"]
+  }
+}
+```
+
+### Usage Example (Child Entity Expansion)
+```json
+{
+  "variable_dcid": "Amount_EconomicActivity_GrossODA",
+  "entities": {
+    "donor": ["country/ARE"]
+  },
+  "parent_entity_property": "recipient",
+  "parent_entity_dcid": "Earth",
+  "child_entity_type": "Country"
+}
+```

--- a/packages/datacommons-mcp/datacommons_mcp/server.py
+++ b/packages/datacommons-mcp/datacommons_mcp/server.py
@@ -64,6 +64,10 @@ if app.settings.use_agent_api:
         agent_api_tools.get_child_observations,
         agent_api_tools.GET_CHILD_OBSERVATIONS_INSTRUCTION_FILE,
     )
+    app.register_tool(
+        agent_api_tools.get_multi_entity_observations,
+        agent_api_tools.GET_MULTI_ENTITY_OBSERVATIONS_INSTRUCTION_FILE,
+    )
 else:
     app.register_tool(
         tools.get_observations,

--- a/packages/datacommons-mcp/tests/test_agent_api.py
+++ b/packages/datacommons-mcp/tests/test_agent_api.py
@@ -86,12 +86,67 @@ async def test_agent_api_service_get_observations():
             "agent/get_observations",
             {
                 "variable_dcid": "Count_Person",
-                "place_dcid": "geoId/06",
-                "child_place_type": "County",
+                "entities": {
+                    "observationAbout": {
+                        "parent_dcid": "geoId/06",
+                        "child_type": "County",
+                    }
+                },
                 "source_override": "USCensus",
                 "date": "latest",
                 "date_range_start": "2020",
                 "date_range_end": "2022",
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_agent_api_service_get_multi_entity_observations():
+    """Verify get_multi_entity_observations builds correct payload for direct and child expansion."""
+    from datacommons_mcp.agent_api_service import get_multi_entity_observations
+    from datacommons_mcp.app import app
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = {"placeObservations": []}
+
+    with patch.object(app, "agent_api_client", mock_client):
+        # Direct DCID map
+        await get_multi_entity_observations(
+            variable_dcid="Amount_EconomicActivity_GrossODA",
+            entities={"donor": ["country/ARE"], "recipient": ["country/AFG"]},
+        )
+        mock_client.post.assert_called_with(
+            "agent/get_observations",
+            {
+                "variable_dcid": "Amount_EconomicActivity_GrossODA",
+                "entities": {"donor": ["country/ARE"], "recipient": ["country/AFG"]},
+                "source_override": None,
+                "date": None,
+                "date_range_start": None,
+                "date_range_end": None,
+            },
+        )
+
+        # Child entity expansion
+        await get_multi_entity_observations(
+            variable_dcid="Amount_EconomicActivity_GrossODA",
+            entities={"donor": ["country/ARE"]},
+            parent_entity_property="recipient",
+            parent_entity_dcid="Earth",
+            child_entity_type="Country",
+        )
+        mock_client.post.assert_called_with(
+            "agent/get_observations",
+            {
+                "variable_dcid": "Amount_EconomicActivity_GrossODA",
+                "entities": {
+                    "donor": ["country/ARE"],
+                    "recipient": {"parent_dcid": "Earth", "child_type": "Country"},
+                },
+                "source_override": None,
+                "date": None,
+                "date_range_start": None,
+                "date_range_end": None,
             },
         )
 

--- a/packages/datacommons-mcp/tests/test_agent_api.py
+++ b/packages/datacommons-mcp/tests/test_agent_api.py
@@ -158,6 +158,18 @@ async def test_agent_api_service_get_multi_entity_observations():
                 parent_entity_property="recipient",
             )
 
+        # Conflicting parent_entity_property in entities should raise ValueError
+        with pytest.raises(
+            ValueError, match="cannot be specified in both 'entities' and child expansion"
+        ):
+            await get_multi_entity_observations(
+                variable_dcid="Amount_EconomicActivity_GrossODA",
+                entities={"donor": ["country/ARE"], "recipient": ["country/AFG"]},
+                parent_entity_property="recipient",
+                parent_entity_dcid="Earth",
+                child_entity_type="Country",
+            )
+
 
 @pytest.mark.asyncio
 async def test_agent_api_service_search_indicators():

--- a/packages/datacommons-mcp/tests/test_agent_api.py
+++ b/packages/datacommons-mcp/tests/test_agent_api.py
@@ -160,7 +160,8 @@ async def test_agent_api_service_get_multi_entity_observations():
 
         # Conflicting parent_entity_property in entities should raise ValueError
         with pytest.raises(
-            ValueError, match="cannot be specified in both 'entities' and child expansion"
+            ValueError,
+            match="cannot be specified in both 'entities' and child expansion",
         ):
             await get_multi_entity_observations(
                 variable_dcid="Amount_EconomicActivity_GrossODA",

--- a/packages/datacommons-mcp/tests/test_agent_api.py
+++ b/packages/datacommons-mcp/tests/test_agent_api.py
@@ -121,7 +121,7 @@ async def test_agent_api_service_get_multi_entity_observations():
                 "variable_dcid": "Amount_EconomicActivity_GrossODA",
                 "entities": {"donor": ["country/ARE"], "recipient": ["country/AFG"]},
                 "source_override": None,
-                "date": None,
+                "date": "latest",
                 "date_range_start": None,
                 "date_range_end": None,
             },
@@ -144,11 +144,19 @@ async def test_agent_api_service_get_multi_entity_observations():
                     "recipient": {"parent_dcid": "Earth", "child_type": "Country"},
                 },
                 "source_override": None,
-                "date": None,
+                "date": "latest",
                 "date_range_start": None,
                 "date_range_end": None,
             },
         )
+
+        # Partial child expansion parameters should raise ValueError
+        with pytest.raises(ValueError, match="To use child entity expansion"):
+            await get_multi_entity_observations(
+                variable_dcid="Amount_EconomicActivity_GrossODA",
+                entities={"donor": ["country/ARE"]},
+                parent_entity_property="recipient",
+            )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Support backend entities map payload construction across all observation API requests
- Add get_multi_entity_observations tool for retrieving multi-entity relationship indicators such as foreign aid flows, bilateral trade, and migration
- Create data-commons-multi-entity-researcher skill detailing multi-entity research workflows and dual-table response parsing
- Add multi-entity discovery routing hooks to standard researcher skills to seamlessly switch skills when multi-entity variables are discovered
- Update server prompt with explicit DCID resolution guidelines and tool date options