### PR TITLE
Add agent_api_root and search_scope configuration options

### DIFF
--- a/packages/datacommons-mcp/.env.sample
+++ b/packages/datacommons-mcp/.env.sample
@@ -75,6 +75,11 @@ DC_TYPE=base
 # Root URL for a non-prod or local Data Commons API (mixer) instance
 # DC_API_ROOT=http://localhost:8081/v2
 
+# Root URL specifically for Data Commons Agent API endpoints (optional)
+# Takes precedence over DC_API_ROOT when DC_USE_AGENT_API=true
+# DC_AGENT_API_ROOT=https://api.datacommons.org/v2
+
 # Root URL for Data Commons API key validation
 # Configure for non-prod environments
 # DC_API_KEY_VALIDATION_ROOT=https://api.datacommons.org
+

--- a/packages/datacommons-mcp/datacommons_mcp/agent_api_client.py
+++ b/packages/datacommons-mcp/datacommons_mcp/agent_api_client.py
@@ -93,7 +93,6 @@ class AgentAPIClient:
         self.timeout = 30.0  # 30 seconds default timeout
         self._client = None
 
-
     @property
     def client(self) -> httpx.AsyncClient:
         """Lazily initialize the AsyncClient under the active event loop."""
@@ -125,7 +124,6 @@ class AgentAPIClient:
         except httpx.RequestError as e:
             error_msg = f"Agent API request to {endpoint} failed: {e}"
             raise AgentAPIError(error_msg, 503, None) from e
-
 
     async def close(self) -> None:
         """Close the underlying HTTP client if it was initialized."""

--- a/packages/datacommons-mcp/datacommons_mcp/agent_api_client.py
+++ b/packages/datacommons-mcp/datacommons_mcp/agent_api_client.py
@@ -68,15 +68,22 @@ def log_api_call(func: Callable[..., Any]) -> Callable[..., Any]:  # noqa: ANN40
 class AgentAPIClient:
     """Async client for interacting with Data Commons agent endpoints."""
 
-    def __init__(self, api_root: str, api_key: str | None = None) -> None:
+    def __init__(
+        self,
+        api_root: str,
+        api_key: str | None = None,
+        search_scope: str | None = None,
+    ) -> None:
         """Initialize the AgentAPIClient.
 
         Args:
             api_root: The base API root URL (e.g. 'https://api.datacommons.org/v2').
             api_key: Optional API key for authentication.
+            search_scope: Optional search scope / target (e.g. 'custom_only', 'base_and_custom').
         """
         self.api_root = api_root.rstrip("/")
         self.api_key = api_key
+        self.search_scope = search_scope
         self.headers = {
             "Content-Type": "application/json",
             "x-surface": f"mcp-{__version__}",
@@ -85,6 +92,7 @@ class AgentAPIClient:
             self.headers["X-API-Key"] = api_key
         self.timeout = 30.0  # 30 seconds default timeout
         self._client = None
+
 
     @property
     def client(self) -> httpx.AsyncClient:
@@ -114,6 +122,10 @@ class AgentAPIClient:
             raise AgentAPIError(
                 error_msg, e.response.status_code, e.response.text
             ) from e
+        except httpx.RequestError as e:
+            error_msg = f"Agent API request to {endpoint} failed: {e}"
+            raise AgentAPIError(error_msg, 503, None) from e
+
 
     async def close(self) -> None:
         """Close the underlying HTTP client if it was initialized."""

--- a/packages/datacommons-mcp/datacommons_mcp/agent_api_service.py
+++ b/packages/datacommons-mcp/datacommons_mcp/agent_api_service.py
@@ -126,7 +126,9 @@ async def search_indicators(
         "parent_place": parent_place,
         "per_search_limit": per_search_limit,
         "include_topics": include_topics,
+        "target": client.search_scope,
     }
+
     return await client.post("agent/search_indicators", payload)
 
 

--- a/packages/datacommons-mcp/datacommons_mcp/app.py
+++ b/packages/datacommons-mcp/datacommons_mcp/app.py
@@ -77,8 +77,8 @@ class DCApp:
                 or self.settings.api_root
                 or "https://api.datacommons.org/v2"
             )
-            api_key = getattr(self.settings, "api_key", None)
-            search_scope = getattr(self.settings, "search_scope", None)
+            api_key = self.settings.api_key
+            search_scope = self.settings.search_scope
             search_scope_str = (
                 search_scope.value if hasattr(search_scope, "value") else search_scope
             )

--- a/packages/datacommons-mcp/datacommons_mcp/app.py
+++ b/packages/datacommons-mcp/datacommons_mcp/app.py
@@ -72,9 +72,24 @@ class DCApp:
         # Create agent API client only if enabled
         self.agent_api_client = None
         if self.settings.use_agent_api:
-            api_root = self.settings.api_root or "https://api.datacommons.org/v2"
+            api_root = (
+                self.settings.agent_api_root
+                or self.settings.api_root
+                or "https://api.datacommons.org/v2"
+            )
             api_key = getattr(self.settings, "api_key", None)
-            self.agent_api_client = AgentAPIClient(api_root=api_root, api_key=api_key)
+            search_scope = getattr(self.settings, "search_scope", None)
+            search_scope_str = (
+                search_scope.value
+                if hasattr(search_scope, "value")
+                else search_scope
+            )
+            self.agent_api_client = AgentAPIClient(
+                api_root=api_root,
+                api_key=api_key,
+                search_scope=search_scope_str,
+            )
+
 
         # Load Server Instructions
         server_instructions = self._load_instructions(SERVER_INSTRUCTIONS_FILE)

--- a/packages/datacommons-mcp/datacommons_mcp/app.py
+++ b/packages/datacommons-mcp/datacommons_mcp/app.py
@@ -80,16 +80,13 @@ class DCApp:
             api_key = getattr(self.settings, "api_key", None)
             search_scope = getattr(self.settings, "search_scope", None)
             search_scope_str = (
-                search_scope.value
-                if hasattr(search_scope, "value")
-                else search_scope
+                search_scope.value if hasattr(search_scope, "value") else search_scope
             )
             self.agent_api_client = AgentAPIClient(
                 api_root=api_root,
                 api_key=api_key,
                 search_scope=search_scope_str,
             )
-
 
         # Load Server Instructions
         server_instructions = self._load_instructions(SERVER_INSTRUCTIONS_FILE)

--- a/packages/datacommons-mcp/datacommons_mcp/data_models/settings.py
+++ b/packages/datacommons-mcp/datacommons_mcp/data_models/settings.py
@@ -65,6 +65,19 @@ class DCSettingsBase(BaseSettings):
         description="API root for Data Commons",
     )
 
+    agent_api_root: str | None = Field(
+        default=None,
+        alias="DC_AGENT_API_ROOT",
+        description="API root specifically for Data Commons Agent API endpoints",
+    )
+
+    search_scope: SearchScope | None = Field(
+        default=None,
+        alias="DC_SEARCH_SCOPE",
+        description="Search scope for queries",
+    )
+
+
 
 class BaseDCSettings(DCSettingsBase):
     """Settings for base Data Commons instance."""

--- a/packages/datacommons-mcp/datacommons_mcp/data_models/settings.py
+++ b/packages/datacommons-mcp/datacommons_mcp/data_models/settings.py
@@ -78,7 +78,6 @@ class DCSettingsBase(BaseSettings):
     )
 
 
-
 class BaseDCSettings(DCSettingsBase):
     """Settings for base Data Commons instance."""
 

--- a/packages/datacommons-mcp/datacommons_mcp/exceptions.py
+++ b/packages/datacommons-mcp/datacommons_mcp/exceptions.py
@@ -54,3 +54,10 @@ class AgentAPIError(Exception):
         super().__init__(message)
         self.status_code = status_code
         self.body = body
+
+    def __str__(self) -> str:
+        base = super().__str__()
+        if self.body:
+            return f"{base} - Body: {self.body}"
+        return base
+

--- a/packages/datacommons-mcp/datacommons_mcp/exceptions.py
+++ b/packages/datacommons-mcp/datacommons_mcp/exceptions.py
@@ -58,5 +58,10 @@ class AgentAPIError(Exception):
     def __str__(self) -> str:
         base = super().__str__()
         if self.body:
-            return f"{base} - Body: {self.body}"
+            truncated_body = (
+                self.body
+                if len(self.body) <= 500
+                else f"{self.body[:500]}... [truncated]"
+            )
+            return f"{base} - Body: {truncated_body}"
         return base

--- a/packages/datacommons-mcp/datacommons_mcp/exceptions.py
+++ b/packages/datacommons-mcp/datacommons_mcp/exceptions.py
@@ -60,4 +60,3 @@ class AgentAPIError(Exception):
         if self.body:
             return f"{base} - Body: {self.body}"
         return base
-

--- a/packages/datacommons-mcp/tests/test_agent_api.py
+++ b/packages/datacommons-mcp/tests/test_agent_api.py
@@ -75,7 +75,6 @@ async def test_agent_api_client_search_scope():
     await client.close()
 
 
-
 @pytest.mark.asyncio
 async def test_agent_api_service_get_observations():
     """Verify get_observations builds correct payload and invokes agent_api_client."""
@@ -214,7 +213,6 @@ async def test_agent_api_service_search_indicators():
                 "target": "custom_only",
             },
         )
-
 
 
 @pytest.mark.asyncio

--- a/packages/datacommons-mcp/tests/test_agent_api.py
+++ b/packages/datacommons-mcp/tests/test_agent_api.py
@@ -64,6 +64,19 @@ async def test_agent_api_client_post():
 
 
 @pytest.mark.asyncio
+async def test_agent_api_client_search_scope():
+    """Verify AgentAPIClient stores search_scope attribute."""
+    client = AgentAPIClient(
+        api_root="https://api.datacommons.org/v2",
+        api_key="test-key",
+        search_scope="custom_only",
+    )
+    assert client.search_scope == "custom_only"
+    await client.close()
+
+
+
+@pytest.mark.asyncio
 async def test_agent_api_service_get_observations():
     """Verify get_observations builds correct payload and invokes agent_api_client."""
     from datacommons_mcp.app import app
@@ -178,6 +191,7 @@ async def test_agent_api_service_search_indicators():
     from datacommons_mcp.app import app
 
     mock_client = AsyncMock()
+    mock_client.search_scope = "custom_only"
     mock_client.post.return_value = {"variables": []}
 
     with patch.object(app, "agent_api_client", mock_client):
@@ -197,8 +211,10 @@ async def test_agent_api_service_search_indicators():
                 "parent_place": "USA",
                 "per_search_limit": 5,
                 "include_topics": False,
+                "target": "custom_only",
             },
         )
+
 
 
 @pytest.mark.asyncio

--- a/packages/datacommons-mcp/tests/test_settings.py
+++ b/packages/datacommons-mcp/tests/test_settings.py
@@ -65,8 +65,7 @@ class TestBaseSettings:
             settings = get_dc_settings()
             assert isinstance(settings, BaseDCSettings)
             assert (
-                settings.agent_api_root
-                == "https://custom-agent-api.datacommons.org/v2"
+                settings.agent_api_root == "https://custom-agent-api.datacommons.org/v2"
             )
             assert settings.search_scope == SearchScope.CUSTOM_ONLY
 
@@ -79,7 +78,6 @@ class TestBaseSettings:
             assert settings.dc_type == "base"
             assert settings.agent_api_root is None
             assert settings.search_scope is None
-
 
 
 class TestCustomSettings:

--- a/packages/datacommons-mcp/tests/test_settings.py
+++ b/packages/datacommons-mcp/tests/test_settings.py
@@ -53,6 +53,23 @@ class TestBaseSettings:
                 "/path/to/cache2.json",
             ]
 
+    def test_loads_with_agent_api_root_and_search_scope(self):
+        """Tests loading agent_api_root and search_scope from environment variables in BaseDCSettings."""
+        env_vars = {
+            "DC_API_KEY": "test_key",
+            "DC_TYPE": "base",
+            "DC_AGENT_API_ROOT": "https://custom-agent-api.datacommons.org/v2",
+            "DC_SEARCH_SCOPE": "custom_only",
+        }
+        with patch.dict(os.environ, env_vars):
+            settings = get_dc_settings()
+            assert isinstance(settings, BaseDCSettings)
+            assert (
+                settings.agent_api_root
+                == "https://custom-agent-api.datacommons.org/v2"
+            )
+            assert settings.search_scope == SearchScope.CUSTOM_ONLY
+
     def test_default_dc_type_is_base(self):
         """Tests that DC_TYPE defaults to 'base' when not provided."""
         env_vars = {"DC_API_KEY": "test_key"}
@@ -60,6 +77,9 @@ class TestBaseSettings:
             settings = get_dc_settings()
             assert isinstance(settings, BaseDCSettings)
             assert settings.dc_type == "base"
+            assert settings.agent_api_root is None
+            assert settings.search_scope is None
+
 
 
 class TestCustomSettings:


### PR DESCRIPTION
## Summary

- Add `DC_AGENT_API_ROOT` environment variable and configuration setting for Agent API base endpoints.
- Add `DC_SEARCH_SCOPE` environment variable and configuration setting to control query search target scope.
- Pass configured search scope in Agent API indicator search requests.
- Wrap HTTP network request failures into 503 Agent API error exceptions.