### PR TITLE
Enable agent API in cloud deployments

### DIFF
--- a/deploy/autopush.yaml
+++ b/deploy/autopush.yaml
@@ -72,6 +72,8 @@ steps:
         --platform=managed \
         --no-allow-unauthenticated \
         --set-env-vars=MCP_VERSION=$(cat _version.txt) \
+        --set-env-vars=DC_USE_AGENT_API=true \
+        --set-env-vars=DC_AGENT_API_ROOT=https://autopush.api.datacommons.org/v2 \
         --set-env-vars=DC_API_ROOT=https://autopush.api.datacommons.org/v2 \
         --set-env-vars=DC_SEARCH_ROOT=https://datacommons.org \
         --set-env-vars=DC_API_KEY_VALIDATION_ROOT=https://autopush.api.datacommons.org \

--- a/deploy/release.yaml
+++ b/deploy/release.yaml
@@ -72,6 +72,8 @@ steps:
         --platform=managed \
         --no-allow-unauthenticated \
         --set-env-vars=MCP_VERSION=$(cat _version.txt) \
+        --set-env-vars=DC_USE_AGENT_API=true \
+        --set-env-vars=DC_AGENT_API_ROOT=https://api.datacommons.org/v2 \
         --set-secrets=DC_API_KEY=dc-api-key-for-mcp:latest \
         --service-account=datacommons-mcp-server@datcom-mixer.iam.gserviceaccount.com \
         --project=datcom-mixer

--- a/deploy/staging.yaml
+++ b/deploy/staging.yaml
@@ -67,6 +67,8 @@ steps:
         --platform=managed \
         --no-allow-unauthenticated \
         --set-env-vars=MCP_VERSION=$(cat _version.txt) \
+        --set-env-vars=DC_USE_AGENT_API=true \
+        --set-env-vars=DC_AGENT_API_ROOT=https://staging.api.datacommons.org/v2 \
         --set-env-vars=DC_API_ROOT=https://staging.api.datacommons.org/v2 \
         --set-env-vars=DC_SEARCH_ROOT=https://staging.datacommons.org \
         --set-env-vars=DC_API_KEY_VALIDATION_ROOT=https://staging.api.datacommons.org \


### PR DESCRIPTION
- Enabled the agent API across Cloud Run deployment workflows (autopush, staging, and production).
- Configured the tier-specific agent API root URLs (DC_AGENT_API_ROOT) in the deployment configurations.